### PR TITLE
Feat: add cbor-sirialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,7 @@ dependencies = [
  "multibase",
  "multihash",
  "serde",
+ "serde_cbor",
 ]
 
 [[package]]
@@ -150,11 +151,17 @@ checksum = "39285b66517a9feda0c28e49a435c585349ea42c3d9bdb1ffefa6077c7962784"
 dependencies = [
  "anyhow",
  "chrono",
- "half",
+ "half 2.6.0",
  "hex",
  "thiserror",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "half"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "half"
@@ -300,6 +307,16 @@ version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
+dependencies = [
+ "half 1.8.3",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ cid = { version = "0.11.1", features = ["serde"] }
 multihash = "0.19.3"
 multibase = "0.9.1"
 serde = { version = "1.0.215", features = ["derive"] }
+serde_cbor = "0.11.0"

--- a/src/dasl/dag_node.rs
+++ b/src/dasl/dag_node.rs
@@ -1,8 +1,8 @@
 use cid::Cid;
+use multihash::Multihash;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
-use serde::de::DeserializeOwned;
-use multihash::Multihash;
 
 /// For more details on these multicodec codes, see:
 /// https://github.com/multiformats/multicodec/blob/master/table.csv
@@ -31,7 +31,7 @@ pub struct DagNode<P, M = BTreeMap<String, String>> {
     pub timestamp: u64,
     pub metadata: M,
 }
-impl<P, M> DagNode<P, M> 
+impl<P, M> DagNode<P, M>
 where
     P: Serialize + DeserializeOwned,
     M: Serialize + DeserializeOwned,
@@ -72,14 +72,6 @@ where
     pub fn metadata(&self) -> &M {
         &self.metadata
     }
-    pub fn verify(&self) -> bool {
-        // todo: verify payload
-        true
-    }
-    pub fn verify_parents(&self) -> bool {
-        // todo: verify parents
-        true
-    }
 }
 
 #[cfg(test)]
@@ -108,19 +100,6 @@ mod tests {
     }
 
     #[test]
-    fn test_entry_with_custom_metadata() {
-        let payload = "test payload".to_string();
-        let parents_cid = create_test_cid(b"test");
-        let parents = vec![parents_cid];
-        let timestamp = 1234567890;
-        let metadata: BTreeMap<String, String> = BTreeMap::new();
-
-        let node = DagNode::new(payload.clone(), parents, timestamp, metadata);
-
-        assert!(node.verify());
-    }
-
-    #[test]
     fn test_entry_multiple_parents() {
         let payload = "test payload".to_string();
         let parents_cid1 = create_test_cid(b"test1");
@@ -144,7 +123,12 @@ mod tests {
         let timestamp = 1234567890;
         let metadata: BTreeMap<String, String> = BTreeMap::new();
 
-        let node = DagNode::new(payload.clone(), parents.clone(), timestamp, metadata.clone());
+        let node = DagNode::new(
+            payload.clone(),
+            parents.clone(),
+            timestamp,
+            metadata.clone(),
+        );
         let bytes = node.to_bytes();
         let node2: DagNode<String, BTreeMap<String, String>> = DagNode::from_bytes(&bytes);
 
@@ -161,36 +145,20 @@ mod tests {
         let parents = vec![parents_cid];
         let timestamp = 1234567890;
         let metadata: BTreeMap<String, String> = BTreeMap::new();
-        let node1 = DagNode::new(payload.clone(), parents.clone(), timestamp, metadata.clone());
-        let node2 = DagNode::new(payload.clone(), parents.clone(), timestamp, metadata.clone());
+        let node1 = DagNode::new(
+            payload.clone(),
+            parents.clone(),
+            timestamp,
+            metadata.clone(),
+        );
+        let node2 = DagNode::new(
+            payload.clone(),
+            parents.clone(),
+            timestamp,
+            metadata.clone(),
+        );
         let content_id1 = node1.content_id();
         let content_id2 = node2.content_id();
         assert_eq!(content_id1.to_string(), content_id2.to_string());
-    }
-
-    #[test]
-    fn test_entry_verify() {
-        let payload = "test payload".to_string();
-        let parents_cid = create_test_cid(b"test");
-        let parents = vec![parents_cid];
-        let timestamp = 1234567890;
-        let metadata: BTreeMap<String, String> = BTreeMap::new();
-        
-        let node = DagNode::new(payload.clone(), parents.clone(), timestamp, metadata.clone());
-
-        assert!(node.verify());
-    }
-
-    #[test]
-    fn test_entry_verify_parents() {
-        let payload = "test payload".to_string();
-        let parents_cid = create_test_cid(b"test");
-        let parents = vec![parents_cid];
-        let timestamp = 1234567890;
-        let metadata: BTreeMap<String, String> = BTreeMap::new();
-
-        let node = DagNode::new(payload.clone(), parents.clone(), timestamp, metadata.clone());
-
-        assert!(node.verify_parents());
     }
 }


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
以下メソッドの実装を行なった。
- `content_id()`
- `to_bytes()`
- `from_bytes()`

シリアライズ、デシリアライズで使用したライブラリ:
- https://docs.rs/serde_cbor/latest/serde_cbor/

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
cborを使い、データ構造が同じの場合同じ配列が出てくるようにした。dCBORを使う予定だったが、一旦は簡易的にcborを使用した。厳重にするにはdcborを使う必要がありそうだが、一旦はcborに留めた。一応[issue](https://github.com/Monas-project/crsl-lib/issues/6)としては記載しておいた。

参考にした実装:
- [ipld](https://github.com/ipld/rust-ipld-core/blob/main/src/ipld.rs)
- [bc-dcbor-rust](https://github.com/BlockchainCommons/bc-dcbor-rust)
