### PR TITLE
Feat: add verify and add_parent method

### DIFF
--- a/src/dasl/dag_node.rs
+++ b/src/dasl/dag_node.rs
@@ -264,7 +264,7 @@ mod tests {
             metadata.clone(),
         );
         let different_cid = different_node.content_id();
-        
+
         assert!(!node.verify_self_integrity(&different_cid));
     }
 
@@ -307,15 +307,15 @@ mod tests {
             timestamp,
             metadata.clone(),
         );
-        
+
         // If the value becomes too large, encoding may not be possible.
         let initial_cid_string = node.content_id().to_string();
-        
+
         let parent2 = create_test_cid(b"b");
         node.add_parent(parent2);
-        
+
         let new_cid_string = node.content_id().to_string();
-        
+
         assert_ne!(initial_cid_string, new_cid_string);
     }
 
@@ -336,7 +336,7 @@ mod tests {
         let parent2 = create_test_cid(b"parent2");
         let parent3 = create_test_cid(b"parent3");
         let parent4 = create_test_cid(b"parent4");
-        
+
         node.add_parent(parent2);
         node.add_parent(parent3);
         node.add_parent(parent4);

--- a/src/dasl/dag_node.rs
+++ b/src/dasl/dag_node.rs
@@ -13,13 +13,13 @@ const RAW_CODE: u64 = 0x55;
 /// This structure can store any type of payload data and metadata, making it versatile for various use cases.
 ///
 /// # Type Parameters
-/// * `P` - Payload type that implements `Serialize` for CID generation.
+/// * `P` - Payload type that implements `Serialize` for content id generation.
 ///   The serialization method for storage is up to the user.
 /// * `M` - The type of the metadata. Defaults to `BTreeMap<String, String>` if not specified.
 ///
 /// # Fields
 /// * `payload` - The main content/data of the entry.
-/// * `parents` - A vector of CIDs (Content Identifiers) pointing to parent entries, forming a DAG structure.
+/// * `parents` - A vector of content ids (Content Identifiers) pointing to parent entries, forming a DAG structure.
 /// * `timestamp` - Unix timestamp representing when the entry was created.
 /// * `metadata` - Additional information about the entry (e.g., author, tags, or other attributes).
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -40,7 +40,7 @@ where
     ///
     /// # Arguments
     /// * `payload` - The main content/data to store in the node
-    /// * `parents` - Vector of CIDs pointing to parent nodes
+    /// * `parents` - Vector of content ids pointing to parent nodes
     /// * `timestamp` - Unix timestamp for node creation time
     /// * `metadata` - Additional information about the node
     ///
@@ -55,10 +55,10 @@ where
         }
     }
 
-    /// Computes the content identifier (CID) for this node
+    /// Computes the content identifier (CID) for the node
     ///
     /// # Returns
-    /// Content ID (Cid) for this node
+    /// Content id (Cid) for the node
     ///
     /// # Errors
     /// Returns a DagNodeError if serialization or hashing fails
@@ -93,20 +93,20 @@ where
         serde_cbor::from_slice(buf).unwrap()
     }
 
-    /// Verifies the integrity of the node by comparing the calculated CID with the expected CID
+    /// Verifies the integrity of the node by comparing the calculated content id with the expected content id
     ///
     /// # Arguments
-    /// * `expected_cid` - The expected CID to compare against
+    /// * `expected_content_id` - The expected content id to compare against
     ///
     /// # Returns
-    /// `true` if the calculated CID matches the expected CID, `false` otherwise
-    pub fn verify_self_integrity(&self, expected_cid: &Cid) -> bool {
+    /// `true` if the calculated content id matches the expected content id, `false` otherwise
+    pub fn verify_self_integrity(&self, expected_content_id: &Cid) -> bool {
         let recalculated = {
             let buf = serde_cbor::to_vec(self).unwrap();
             let mh = Multihash::<64>::wrap(SHA2_256_CODE, &buf).unwrap();
             Cid::new_v1(RAW_CODE, mh)
         };
-        recalculated == *expected_cid
+        recalculated == *expected_content_id
     }
 
     pub fn add_parent(&mut self, cid: Cid) {
@@ -132,7 +132,7 @@ mod tests {
     use super::*;
     use std::collections::BTreeMap;
 
-    fn create_test_cid(data: &[u8]) -> Cid {
+    fn create_test_content_id(data: &[u8]) -> Cid {
         use multihash::Multihash;
         let code = 0x12;
         let digest = Multihash::<64>::wrap(code, data).unwrap();
@@ -142,39 +142,39 @@ mod tests {
     #[test]
     fn test_entry_creation_with_default_metadata() {
         let payload = "test payload".to_string();
-        let parents_cid = create_test_cid(b"test");
-        let parents = vec![parents_cid];
+        let parents_content_id = create_test_content_id(b"test");
+        let parents = vec![parents_content_id];
         let timestamp = 1234567890;
         let metadata: BTreeMap<String, String> = BTreeMap::new();
 
         let node = DagNode::new(payload.clone(), parents, timestamp, metadata);
 
         assert_eq!(node.payload(), &payload);
-        assert_eq!(node.parents(), &vec![parents_cid]);
+        assert_eq!(node.parents(), &vec![parents_content_id]);
         assert_eq!(node.timestamp(), timestamp);
     }
 
     #[test]
     fn test_entry_multiple_parents() {
         let payload = "test payload".to_string();
-        let parents_cid1 = create_test_cid(b"test1");
-        let parents_cid2 = create_test_cid(b"test2");
-        let parents = vec![parents_cid1, parents_cid2];
+        let parents_content_id1 = create_test_content_id(b"test1");
+        let parents_content_id2 = create_test_content_id(b"test2");
+        let parents = vec![parents_content_id1, parents_content_id2];
         let timestamp = 1234567890;
         let metadata: BTreeMap<String, String> = BTreeMap::new();
 
         let node = DagNode::new(payload.clone(), parents, timestamp, metadata);
 
         assert_eq!(node.parents().len(), 2);
-        assert_eq!(node.parents()[0], parents_cid1);
-        assert_eq!(node.parents()[1], parents_cid2);
+        assert_eq!(node.parents()[0], parents_content_id1);
+        assert_eq!(node.parents()[1], parents_content_id2);
     }
 
     #[test]
     fn test_to_bytes_roundtrip() {
         let payload = "test".to_string();
-        let parents_cid = create_test_cid(b"test");
-        let parents = vec![parents_cid];
+        let parents_content_id = create_test_content_id(b"test");
+        let parents = vec![parents_content_id];
         let timestamp = 1234567890;
         let metadata: BTreeMap<String, String> = BTreeMap::new();
 
@@ -197,8 +197,8 @@ mod tests {
     #[test]
     fn test_content_id() {
         let payload = "test".to_string();
-        let parents_cid = create_test_cid(b"test");
-        let parents = vec![parents_cid];
+        let parents_content_id = create_test_content_id(b"test");
+        let parents = vec![parents_content_id];
         let timestamp = 1234567890;
         let metadata: BTreeMap<String, String> = BTreeMap::new();
 
@@ -225,8 +225,8 @@ mod tests {
     #[test]
     fn test_verify_self_integrity_with_correct_cid() {
         let payload = "test".to_string();
-        let parents_cid = create_test_cid(b"test");
-        let parents = vec![parents_cid];
+        let parents_content_id = create_test_content_id(b"test");
+        let parents = vec![parents_content_id];
         let timestamp = 1234567890;
         let metadata: BTreeMap<String, String> = BTreeMap::new();
 
@@ -244,8 +244,8 @@ mod tests {
     #[test]
     fn test_verify_self_integrity_with_wrong_cid() {
         let payload = "test".to_string();
-        let parents_cid = create_test_cid(b"test");
-        let parents = vec![parents_cid];
+        let parents_content_id = create_test_content_id(b"test");
+        let parents = vec![parents_content_id];
         let timestamp = 1234567890;
         let metadata: BTreeMap<String, String> = BTreeMap::new();
 
@@ -271,7 +271,7 @@ mod tests {
     #[test]
     fn test_add_parent_basic() {
         let payload = "test payload".to_string();
-        let parent1 = create_test_cid(b"parent1");
+        let parent1 = create_test_content_id(b"parent1");
         let initial_parents = vec![parent1];
         let timestamp = 1234567890;
         let metadata: BTreeMap<String, String> = BTreeMap::new();
@@ -285,7 +285,7 @@ mod tests {
 
         assert_eq!(node.parents().len(), 1);
         assert_eq!(node.parents()[0], parent1);
-        let parent2 = create_test_cid(b"parent2");
+        let parent2 = create_test_content_id(b"parent2");
         node.add_parent(parent2);
 
         assert_eq!(node.parents().len(), 2);
@@ -296,7 +296,7 @@ mod tests {
     #[test]
     fn test_add_parent_changes_cid() {
         let payload = "test".to_string();
-        let parent1 = create_test_cid(b"parent1");
+        let parent1 = create_test_content_id(b"parent1");
         let initial_parents = vec![parent1];
         let timestamp = 1;
         let metadata: BTreeMap<String, String> = BTreeMap::new();
@@ -311,7 +311,7 @@ mod tests {
         // If the value becomes too large, encoding may not be possible.
         let initial_cid_string = node.content_id().to_string();
 
-        let parent2 = create_test_cid(b"b");
+        let parent2 = create_test_content_id(b"b");
         node.add_parent(parent2);
 
         let new_cid_string = node.content_id().to_string();
@@ -322,7 +322,7 @@ mod tests {
     #[test]
     fn test_add_multiple_parents() {
         let payload = "test payload".to_string();
-        let parent1 = create_test_cid(b"parent1");
+        let parent1 = create_test_content_id(b"parent1");
         let initial_parents = vec![parent1];
         let timestamp = 1234567890;
         let metadata: BTreeMap<String, String> = BTreeMap::new();
@@ -333,9 +333,9 @@ mod tests {
             timestamp,
             metadata.clone(),
         );
-        let parent2 = create_test_cid(b"parent2");
-        let parent3 = create_test_cid(b"parent3");
-        let parent4 = create_test_cid(b"parent4");
+        let parent2 = create_test_content_id(b"parent2");
+        let parent3 = create_test_content_id(b"parent3");
+        let parent4 = create_test_content_id(b"parent4");
 
         node.add_parent(parent2);
         node.add_parent(parent3);


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
以下機能を追加と修正:
- `verify_self_integrity()`: 実際のデータと一致するかを検証
-  `add_parent`
- cidをcontent_idに修正

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
- `verify_self_integrity`は、このメソッドを使わなくても表現は可能だと思う。そのため、必要ない可能性もあるが、定義しておいた。
- dag_nodeとしているが、非巡回グラフであることは保てていないため、名前の変更が必要かもしれない