### PR TITLE
Feat: Add verification method and test for dag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.98"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,14 +139,14 @@ dependencies = [
 
 [[package]]
 name = "dcbor"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39285b66517a9feda0c28e49a435c585349ea42c3d9bdb1ffefa6077c7962784"
+checksum = "acd7515d6680292a81c11bd3371c7e553c0780371d932d6e6797e7e99ee38aff"
 dependencies = [
- "anyhow",
  "chrono",
  "half 2.6.0",
  "hex",
+ "paste",
  "thiserror",
  "unicode-normalization",
 ]
@@ -267,6 +261,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.79"
 
 [dependencies]
-dcbor = "0.17.0"
+dcbor = "0.18.0"
 cid = { version = "0.11.1", features = ["serde"] }
 multihash = "0.19.3"
 multibase = "0.9.1"

--- a/src/dasl/mod.rs
+++ b/src/dasl/mod.rs
@@ -1,2 +1,2 @@
 pub mod cid;
-pub mod dag_node;
+pub mod node;

--- a/src/graph/dag.rs
+++ b/src/graph/dag.rs
@@ -87,9 +87,9 @@ mod tests {
         fn setup_graph(&mut self, structure: &[(Cid, Cid)]) {
             for (parent, child) in structure {
                 self.edges
-                    .entry(parent.clone())
-                    .or_insert_with(Vec::new)
-                    .push(child.clone());
+                    .entry(*parent)
+                    .or_default()
+                    .push(*child);
             }
         }
     }
@@ -118,7 +118,7 @@ mod tests {
         let cid1 = create_test_content_id(b"node1");
         let cid2 = create_test_content_id(b"node2");
         let cid3 = create_test_content_id(b"node3");
-        storage.setup_graph(&[(cid1.clone(), cid2.clone()), (cid2.clone(), cid3.clone())]);
+        storage.setup_graph(&[(cid1, cid2), (cid2, cid3)]);
         let dag = DagGraph::<_, String, BTreeMap<String, String>>::new(storage);
 
         // 新しいノードを追加

--- a/src/graph/dag.rs
+++ b/src/graph/dag.rs
@@ -1,0 +1,68 @@
+use crate::graph::storage::NodeStorage;
+use cid::Cid;
+use std::collections::HashSet;
+use std::marker::PhantomData;
+
+/// エラーの種類を表す列挙型
+#[derive(Debug)]
+pub enum GraphError {
+    CycleDetected,
+    NodeNotFound,
+    StorageError,
+}
+
+#[derive(Debug)]
+pub struct DagGraph<S, P, M>
+where
+    S: NodeStorage<P, M>,
+{
+    _storage: S,
+    _p_marker: PhantomData<P>,
+    _m_marker: PhantomData<M>,
+}
+
+impl<S, P, M> DagGraph<S, P, M>
+where
+    S: NodeStorage<P, M>,
+    P: serde::Serialize + serde::de::DeserializeOwned,
+    M: serde::Serialize + serde::de::DeserializeOwned,
+{
+    pub fn new(storage: S) -> Self {
+        Self {
+            _storage: storage,
+            _p_marker: PhantomData,
+            _m_marker: PhantomData,
+        }
+    }
+
+    pub fn try_add_edge(&mut self, parent_cid: &Cid, child_cid: &Cid) -> Result<(), GraphError> {
+        if self.would_create_cycle(parent_cid, child_cid)? {
+            return Err(GraphError::CycleDetected);
+        }
+
+        Ok(())
+    }
+
+    /// Check if adding an edge would create a cycle
+    fn would_create_cycle(&self, from: &Cid, to: &Cid) -> Result<bool, GraphError> {
+        let mut visited = HashSet::new();
+        self.detect_cycle(to, from, &mut visited)
+    }
+
+    fn detect_cycle(
+        &self,
+        current: &Cid,
+        target: &Cid,
+        visited: &mut HashSet<Cid>,
+    ) -> Result<bool, GraphError> {
+        if current == target {
+            return Ok(true);
+        }
+
+        if !visited.insert(*current) {
+            return Ok(false);
+        }
+
+        Ok(false)
+    }
+}

--- a/src/graph/dag.rs
+++ b/src/graph/dag.rs
@@ -86,10 +86,7 @@ mod tests {
 
         fn setup_graph(&mut self, structure: &[(Cid, Cid)]) {
             for (parent, child) in structure {
-                self.edges
-                    .entry(*parent)
-                    .or_default()
-                    .push(*child);
+                self.edges.entry(*parent).or_default().push(*child);
             }
         }
     }

--- a/src/graph/dag.rs
+++ b/src/graph/dag.rs
@@ -66,3 +66,78 @@ where
         Ok(false)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dasl::node::Node;
+    use std::collections::{BTreeMap, HashMap};
+
+    #[derive(Debug)]
+    struct MockStorage {
+        edges: HashMap<Cid, Vec<Cid>>,
+    }
+    impl MockStorage {
+        fn new() -> Self {
+            Self {
+                edges: HashMap::new(),
+            }
+        }
+
+        fn setup_graph(&mut self, structure: &[(Cid, Cid)]) {
+            for (parent, child) in structure {
+                self.edges
+                    .entry(parent.clone())
+                    .or_insert_with(Vec::new)
+                    .push(child.clone());
+            }
+        }
+    }
+
+    impl<P, M> NodeStorage<P, M> for MockStorage {
+        fn get(&self, _content_id: &Cid) -> Option<Node<P, M>> {
+            None
+        }
+
+        fn put(&mut self, _node: &Node<P, M>) {}
+
+        fn delete(&mut self, _content_id: &Cid) {}
+    }
+
+    fn create_test_content_id(data: &[u8]) -> Cid {
+        use multihash::Multihash;
+        let code = 0x12;
+        let digest = Multihash::<64>::wrap(code, data).unwrap();
+        Cid::new_v1(0x55, digest)
+    }
+
+    #[test]
+    fn test_no_cycle_in_simple_pash() {
+        // 単純なパス 1 -> 2 -> 3
+        let mut storage = MockStorage::new();
+        let cid1 = create_test_content_id(b"node1");
+        let cid2 = create_test_content_id(b"node2");
+        let cid3 = create_test_content_id(b"node3");
+        storage.setup_graph(&[(cid1.clone(), cid2.clone()), (cid2.clone(), cid3.clone())]);
+        let dag = DagGraph::<_, String, BTreeMap<String, String>>::new(storage);
+
+        // 新しいノードを追加
+        let cid4 = create_test_content_id(b"node4");
+        let result = dag.would_create_cycle(&cid3, &cid4);
+        assert!(result.is_ok());
+        assert!(!result.unwrap(), "false");
+    }
+
+    #[test]
+    fn test_empty_graph_has_no_cycles() {
+        let storage = MockStorage::new();
+        let dag = DagGraph::<_, String, BTreeMap<String, String>>::new(storage);
+
+        let cid1 = create_test_content_id(b"node1");
+        let cid2 = create_test_content_id(b"node2");
+        let result = dag.would_create_cycle(&cid1, &cid2);
+
+        assert!(result.is_ok());
+        assert!(!result.unwrap(), "false");
+    }
+}

--- a/src/graph/dag.rs
+++ b/src/graph/dag.rs
@@ -1,7 +1,9 @@
+use crate::dasl::node::Node;
 use crate::graph::storage::NodeStorage;
 use cid::Cid;
 use std::collections::HashSet;
 use std::marker::PhantomData;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 /// エラーの種類を表す列挙型
 #[derive(Debug)]
@@ -11,12 +13,19 @@ pub enum GraphError {
     StorageError,
 }
 
+/// Directed Acyclic Graph(DAG) Structure
+///
+/// # Arguments
+///
+/// * `S` - NodeStorage
+/// * `P` - Payload
+/// * `M` - Metadata
 #[derive(Debug)]
 pub struct DagGraph<S, P, M>
 where
     S: NodeStorage<P, M>,
 {
-    _storage: S,
+    storage: S,
     _p_marker: PhantomData<P>,
     _m_marker: PhantomData<M>,
 }
@@ -29,26 +38,78 @@ where
 {
     pub fn new(storage: S) -> Self {
         Self {
-            _storage: storage,
+            storage,
             _p_marker: PhantomData,
             _m_marker: PhantomData,
         }
     }
 
-    pub fn try_add_edge(&mut self, parent_cid: &Cid, child_cid: &Cid) -> Result<(), GraphError> {
-        if self.would_create_cycle(parent_cid, child_cid)? {
-            return Err(GraphError::CycleDetected);
+    /// Add an edge to the graph
+    ///
+    /// # Arguments
+    ///
+    /// * `payload` - The payload
+    /// * `parents` - The parent content Ids
+    /// * `metadata` - The metadata
+    ///
+    /// # Returns
+    ///
+    /// * `Cid` - The content Id of the new node
+    ///
+    pub fn add_node(
+        &mut self,
+        payload: P,
+        parents: Vec<Cid>,
+        metadata: M,
+    ) -> Result<Cid, GraphError> {
+        let timestamp = Self::current_timestamp()?;
+        let node = Node::new(payload, parents.clone(), timestamp, metadata);
+        for parent in &parents {
+            if self.would_create_cycle(parent, &node.content_id())? {
+                return Err(GraphError::CycleDetected);
+            }
         }
+        self.storage.put(&node);
+        Ok(node.content_id())
+    }
 
-        Ok(())
+    fn current_timestamp() -> Result<u64, GraphError> {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| GraphError::StorageError)
+            .map(|d| d.as_secs())
     }
 
     /// Check if adding an edge would create a cycle
-    fn would_create_cycle(&self, from: &Cid, to: &Cid) -> Result<bool, GraphError> {
+    ///
+    /// # Arguments
+    ///
+    /// * `parent_cid` - The parent content Id
+    /// * `child_cid` - The child content Id
+    ///
+    /// # Returns
+    ///
+    /// * `true` - If a cycle is detected
+    /// * `false` - If no cycle is detected
+    ///
+    fn would_create_cycle(&self, parent_cid: &Cid, child_cid: &Cid) -> Result<bool, GraphError> {
         let mut visited = HashSet::new();
-        self.detect_cycle(to, from, &mut visited)
+        self.detect_cycle(child_cid, parent_cid, &mut visited)
     }
 
+    /// Detect a cycle in the graph
+    ///
+    /// # Arguments
+    ///
+    /// * `current` - The current content Id
+    /// * `target` - The target content Id
+    /// * `visited` - The visited content Ids
+    ///
+    /// # Returns
+    ///
+    /// * `true` - If a cycle is detected
+    /// * `false` - If no cycle is detected
+    ///
     fn detect_cycle(
         &self,
         current: &Cid,
@@ -58,11 +119,15 @@ where
         if current == target {
             return Ok(true);
         }
-
         if !visited.insert(*current) {
             return Ok(false);
         }
-
+        let node = self.storage.get(current).ok_or(GraphError::NodeNotFound)?;
+        for parent_cid in node.parents() {
+            if self.detect_cycle(parent_cid, target, visited)? {
+                return Ok(true);
+            }
+        }
         Ok(false)
     }
 }
@@ -86,14 +151,23 @@ mod tests {
 
         fn setup_graph(&mut self, structure: &[(Cid, Cid)]) {
             for (parent, child) in structure {
-                self.edges.entry(*parent).or_default().push(*child);
+                self.edges.entry(*child).or_default().push(*parent);
             }
         }
     }
 
-    impl<P, M> NodeStorage<P, M> for MockStorage {
-        fn get(&self, _content_id: &Cid) -> Option<Node<P, M>> {
-            None
+    impl<P, M> NodeStorage<P, M> for MockStorage
+    where
+        P: Default + serde::Serialize + serde::de::DeserializeOwned,
+        M: Default + serde::Serialize + serde::de::DeserializeOwned,
+    {
+        fn get(&self, content_id: &Cid) -> Option<Node<P, M>> {
+            Some(Node::new(
+                P::default(),
+                self.edges.get(content_id).cloned().unwrap_or_default(),
+                0,
+                M::default(),
+            ))
         }
 
         fn put(&mut self, _node: &Node<P, M>) {}
@@ -109,18 +183,18 @@ mod tests {
     }
 
     #[test]
-    fn test_no_cycle_in_simple_pash() {
-        // 単純なパス 1 -> 2 -> 3
+    fn test_no_cycle_in_simple_path() {
+        // 単純なパス A -> B -> C
         let mut storage = MockStorage::new();
-        let cid1 = create_test_content_id(b"node1");
-        let cid2 = create_test_content_id(b"node2");
-        let cid3 = create_test_content_id(b"node3");
-        storage.setup_graph(&[(cid1, cid2), (cid2, cid3)]);
+        let cid_a = create_test_content_id(b"node_a");
+        let cid_b = create_test_content_id(b"node_b");
+        let cid_c = create_test_content_id(b"node_c");
+        let cid_d = create_test_content_id(b"node_d");
+        storage.setup_graph(&[(cid_b, cid_a), (cid_c, cid_b)]);
         let dag = DagGraph::<_, String, BTreeMap<String, String>>::new(storage);
 
-        // 新しいノードを追加
-        let cid4 = create_test_content_id(b"node4");
-        let result = dag.would_create_cycle(&cid3, &cid4);
+        let result = dag.would_create_cycle(&cid_d, &cid_c);
+
         assert!(result.is_ok());
         assert!(!result.unwrap(), "false");
     }
@@ -130,11 +204,68 @@ mod tests {
         let storage = MockStorage::new();
         let dag = DagGraph::<_, String, BTreeMap<String, String>>::new(storage);
 
-        let cid1 = create_test_content_id(b"node1");
-        let cid2 = create_test_content_id(b"node2");
-        let result = dag.would_create_cycle(&cid1, &cid2);
+        let cid_a = create_test_content_id(b"node_a");
+        let cid_b = create_test_content_id(b"node_b");
+        let result = dag.would_create_cycle(&cid_a, &cid_b);
 
         assert!(result.is_ok());
         assert!(!result.unwrap(), "false");
+    }
+    #[test]
+    fn test_direct_cycle_detection() {
+        let mut storage = MockStorage::new();
+        let cid_a = create_test_content_id(b"node_a");
+        let cid_b = create_test_content_id(b"node_b");
+        storage.setup_graph(&[(cid_a, cid_b)]);
+        let dag = DagGraph::<_, String, BTreeMap<String, String>>::new(storage);
+        let result = dag.would_create_cycle(&cid_a, &cid_b);
+
+        assert!(result.is_ok());
+        assert!(result.unwrap(), "true");
+    }
+
+    #[test]
+    fn test_long_path_cycle_detection() {
+        // 1 -> 2 -> 3 -> 4 : 4 -> 1 this is a cycle
+        let mut storage = MockStorage::new();
+        let cid_a = create_test_content_id(b"node_a");
+        let cid_b = create_test_content_id(b"node_b");
+        let cid_c = create_test_content_id(b"node_c");
+        let cid_d = create_test_content_id(b"node_d");
+        storage.setup_graph(&[(cid_b, cid_a), (cid_c, cid_b), (cid_d, cid_c)]);
+        let dag = DagGraph::<_, String, BTreeMap<String, String>>::new(storage);
+
+        let result = dag.would_create_cycle(&cid_d, &cid_a);
+
+        assert!(result.is_ok());
+        assert!(result.unwrap(), "true");
+    }
+
+    // multi path cycle detection
+    //    A
+    //   ↗ ↘
+    //  B     C
+    // ↗ ↘   ↗
+    // D   E ← A
+    #[test]
+    fn test_multi_path_cycle_detection() {
+        let mut storage = MockStorage::new();
+        let cid_a = create_test_content_id(b"node_a");
+        let cid_b = create_test_content_id(b"node_b");
+        let cid_c = create_test_content_id(b"node_c");
+        let cid_d = create_test_content_id(b"node_d");
+        let cid_e = create_test_content_id(b"node_e");
+        storage.setup_graph(&[
+            (cid_b, cid_a),
+            (cid_c, cid_a),
+            (cid_d, cid_b),
+            (cid_e, cid_b),
+            (cid_e, cid_c),
+        ]);
+        let dag = DagGraph::<_, String, BTreeMap<String, String>>::new(storage);
+
+        let result = dag.would_create_cycle(&cid_e, &cid_a);
+        assert!(result.is_ok());
+        assert!(result.unwrap(), "true");
     }
 }

--- a/src/graph/dag.rs
+++ b/src/graph/dag.rs
@@ -25,7 +25,7 @@ pub struct DagGraph<S, P, M>
 where
     S: NodeStorage<P, M>,
 {
-    storage: S,
+    pub storage: S,
     _p_marker: PhantomData<P>,
     _m_marker: PhantomData<M>,
 }

--- a/src/graph/dag.rs
+++ b/src/graph/dag.rs
@@ -184,7 +184,7 @@ mod tests {
 
     #[test]
     fn test_no_cycle_in_simple_path() {
-        // 単純なパス A -> B -> C
+        // simple path A -> B -> C
         let mut storage = MockStorage::new();
         let cid_a = create_test_content_id(b"node_a");
         let cid_b = create_test_content_id(b"node_b");
@@ -241,14 +241,14 @@ mod tests {
         assert!(result.unwrap(), "true");
     }
 
-    // multi path cycle detection
-    //    A
-    //   ↗ ↘
-    //  B     C
-    // ↗ ↘   ↗
-    // D   E ← A
     #[test]
     fn test_multi_path_cycle_detection() {
+        // multi path cycle detection
+        //    A
+        //   ↗ ↘
+        //  B     C
+        // ↗ ↘   ↗
+        // D   E ← A
         let mut storage = MockStorage::new();
         let cid_a = create_test_content_id(b"node_a");
         let cid_b = create_test_content_id(b"node_b");

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -1,0 +1,2 @@
+pub mod dag;
+pub mod storage;

--- a/src/graph/storage.rs
+++ b/src/graph/storage.rs
@@ -1,0 +1,9 @@
+use crate::dasl::node::Node;
+use cid::Cid;
+
+// todo: error handling
+pub trait NodeStorage<P, M> {
+    fn get(&self, content_id: &Cid) -> Option<Node<P, M>>;
+    fn put(&mut self, node: &Node<P, M>);
+    fn delete(&mut self, content_id: &Cid);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod crdt;
 pub mod dasl;
+pub mod graph;
 pub mod masl;


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
以下修正:
- `DagNode構造体`を`Node構造体`に変更

以下機能を実装:
- 非循環有向グラフの実装
  - ノード間の親子関係を管理するDagGraph構造体を実装
  - サイクル（循環）を検出するアルゴリズムを実装
  - 親ノードから子ノードへの新しいエッジ追加時にサイクル検出を行い、DAGの性質を維持
- サイクル検出アルゴリズム
  - 再帰的なパス探索を使用してサイクルを検出
  - 子ノードから親方向へたどってパスが存在するかをチェック
  - 訪問済みノードを追跡して無限ループを回避
- ストレージを抽象化
  - NodeStorageトレイトによるストレージ層の抽象化
  - 様々なバックエンドストレージ実装に対応可能な柔軟な設計
  - ノードの取得・保存・削除の基本操作をサポート

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
### Notes
- サイクル検出アルゴリズムはもっと早くできる可能性がある
- child nodeの追加ってのを追加しても良いかもしれない
  - edgeを保存することで、parent -> child, child -> parentってのを両方探索することができそう

### `Node構造体`との関係性:
[Node構造体](https://github.com/Monas-project/crsl-lib/blob/10b3dd2aa0ed9ee0c5dc7f86b620f36d43d7fd4e/src/dasl/node.rs#L26)は、なるべくピュアなロジックで最小の依存のみで実装したかったため、DagGraph構造体と分離した。

dag.rsとnode.rsの連携は以下のようなフローで行われる：
1. ユーザーはNode構造体を使ってデータを表現する
2. DAGグラフはNodeStorageトレイトを通じてノードにアクセスする
4. 新しいエッジを追加する際には、DAGグラフがサイクル検出を行い、DAGの性質を保証する
5. 実際のノードの保存や取得はストレージ層に委任され、メモリ内キャッシュなど様々な最適化が可能

**使い方例:**
初期化:
```rust
let storage = MemStorage::new();
let mut doc_graph = DagGraph::new(storage);
```

Vrsionを初めて作成する場合:
```rust
let doc = Document { content: "version_1", author: "bob" };
let v1_cid = doc_graph.add_node(doc, vec![], BTreeMap::new()).unwrap();
```

派生する場合:
```rust
let doc_v2 = Document { content: "version_2", author: "alice" };
let v2_cid = doc_graph.add_node(doc_v2, vec![v1_cid], BTreeMap::new()).unwrap();
```

分岐する場合:
```rust
let doc_v3 = Document { content: "version_2'", author: "soma" };
let v3_cid = doc_graph.add_node(doc_v3, vec![v1_cid], BTreeMap::new()).unwrap();
```
