### PR TITLE
Feat: Implementation of CRDT operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
+name = "bitflags"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +207,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
+ "ulid",
 ]
 
 [[package]]
@@ -247,6 +254,18 @@ dependencies = [
  "paste",
  "thiserror",
  "unicode-normalization",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi",
 ]
 
 [[package]]
@@ -385,6 +404,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +428,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -524,6 +587,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand",
+ "serde",
+ "web-time",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +623,15 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -606,6 +689,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -739,3 +832,32 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ serde = { version = "1.0.215", features = ["derive"] }
 serde_cbor = "0.11.0"
 clap = { version = "4.5.11", features = ["derive"] }
 serde_json = "1.0.100"
+ulid = { version = "1.2.0", features = ["serde"] }
 
 [[example]]
 name = "cli"

--- a/src/crdt/mod.rs
+++ b/src/crdt/mod.rs
@@ -1,1 +1,1 @@
-
+pub mod operation;

--- a/src/crdt/operation.rs
+++ b/src/crdt/operation.rs
@@ -27,7 +27,7 @@ pub enum OperationType<T> {
     Delete,
 }
 
- /// Helper methods to check the operation type
+/// Helper methods to check the operation type
 impl<T> OperationType<T> {
     pub fn as_kind(&self) -> OperationKind {
         match self {

--- a/src/crdt/operation.rs
+++ b/src/crdt/operation.rs
@@ -2,10 +2,16 @@ use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use ulid::Ulid;
 
+/// Unique identifier for operations (based on Ulid)
 pub type OperationId = Ulid;
 pub type Author = String;
 pub type Timestamp = u64;
 
+/// Enum representing the type of operation
+///
+/// Create: Create a new content
+/// Update: Update an existing content
+/// Delete: Delete an existing content
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum OperationType<T> {
     Create(T),
@@ -13,6 +19,15 @@ pub enum OperationType<T> {
     Delete,
 }
 
+/// Structure representing a CRDT operation
+///
+/// Each operation represents a create, update, or delete action on a target content.
+/// Operations include a unique ID, execution timestamp, and information about the executor.
+///
+/// # Type Parameters
+///
+/// * `ContentId` - Type identifying the target content
+/// * `T` - Type of the payload data for the operation
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Operation<ContentId, T> {
     pub id: OperationId,
@@ -27,12 +42,22 @@ where
     ContentId: Clone + Debug + Serialize,
     T: Clone + Debug + Serialize,
 {
+    /// Creates a new operation
+    ///
+    /// # Arguments
+    ///
+    /// * `target` - ID of the content being operated on
+    /// * `kind` - Type of operation and its payload
+    /// * `author` - User/system performing the operation
+    ///
+    /// # Returns
+    ///
+    /// A newly created operation object
     pub fn new(target: ContentId, kind: OperationType<T>, author: Author) -> Self {
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_millis() as Timestamp;
-        // Use UlId to make sorting possible.
         let id = Ulid::new();
         Self {
             id,
@@ -43,18 +68,34 @@ where
         }
     }
 
+    /// Helper methods to check the operation type
+    ///
+    /// The following methods provide a convenient way to check what type of operation this is.
+    /// Instead of directly pattern matching on the `kind` field, you can use these helper methods.
+    ///
+    /// Checks if this operation is a delete operation
     pub fn is_delete(&self) -> bool {
         matches!(self.kind, OperationType::Delete)
     }
 
+    /// Checks if this operation is a create operation
     pub fn is_create(&self) -> bool {
         matches!(self.kind, OperationType::Create(_))
     }
 
+    /// Checks if this operation is an update operation
     pub fn is_update(&self) -> bool {
         matches!(self.kind, OperationType::Update(_))
     }
 
+    /// Gets the payload of the operation
+    ///
+    /// Delete operations have no payload, so this returns `None` for them.
+    ///
+    /// # Returns
+    ///
+    /// `Some` containing a reference to the payload for create/update operations,
+    /// or `None` for delete operations
     pub fn payload(&self) -> Option<&T> {
         match &self.kind {
             OperationType::Create(v) | OperationType::Update(v) => Some(v),

--- a/src/crdt/operation.rs
+++ b/src/crdt/operation.rs
@@ -1,9 +1,12 @@
+use std::fmt::Debug;
+use serde::Serialize;
+
 pub type OperationId = u128;
 pub type Author = String;
 pub type Signature = String;
 pub type Timestamp = u64;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub enum OperationType<T> {
     Create(T),
     Update(T),
@@ -19,7 +22,11 @@ pub struct Operation<ContentId, T> {
     pub signature: Option<Signature>,
 }
 
-impl<ContentId, T> Operation<ContentId, T> {
+impl<ContentId, T> Operation<ContentId, T> 
+where 
+    ContentId: Clone + Debug + Serialize,
+    T: Clone + Debug + Serialize,
+{
     pub fn new(target: ContentId, kind: OperationType<T>, author: Author) -> Self {
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -32,6 +39,85 @@ impl<ContentId, T> Operation<ContentId, T> {
     pub fn verify_signature(&self) -> bool {
         true
     }
+
+    pub fn is_delete(&self) -> bool {
+        matches!(self.kind, OperationType::Delete)
+    }
+
+    pub fn is_create(&self) -> bool {
+        matches!(self.kind, OperationType::Create(_))
+    }
+
+    pub fn payload(&self) -> Option<&T> {
+        match &self.kind {  
+            OperationType::Create(v) | OperationType::Update(v) => Some(v),
+            OperationType::Delete => None,
+        }
+    }
 }
 
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Debug, PartialEq,Serialize)]
+    struct DummyContentId(String);
+
+    #[derive(Clone, Debug, Serialize, PartialEq)]
+    struct DummyPayload(String);
+
+    #[test]
+    fn test_operation_create() {
+        let target = DummyContentId("test".into());
+        let payload = DummyPayload("test".into());
+        let author = "Alice".to_string();
+
+        let op = Operation::new(target.clone(), OperationType::Create(payload.clone()), author.clone());
+
+        assert_eq!(op.id, 0);
+        assert_eq!(op.target, target);
+        assert_eq!(op.kind, OperationType::Create(payload.clone()));
+        assert!(op.timestamp > 0);
+        assert_eq!(op.author, author);
+        assert_eq!(op.payload(), Some(&payload));
+        assert!(op.is_create());
+        assert!(!op.is_delete());
+    }
+
+    #[test]
+    fn test_operation_update() {
+        let target = DummyContentId("test".into());
+        let payload = DummyPayload("updated".into());
+        let author = "Alice".to_string();
+
+        let op = Operation::new(target.clone(), OperationType::Update(payload.clone()), author.clone());
+
+        assert_eq!(op.id, 0);
+        assert_eq!(op.target, target);
+        assert_eq!(op.kind, OperationType::Update(payload.clone()));
+        assert!(op.timestamp > 0);
+        assert_eq!(op.author, author);
+        assert_eq!(op.payload(), Some(&payload));
+        assert!(!op.is_create());
+        assert!(!op.is_delete());
+    }
+
+    #[test]
+    fn test_operation_delete() {
+        let target = DummyContentId("test".into());
+        let author = "Alice".to_string();
+
+        let op = Operation::<DummyContentId, DummyPayload>::new(target.clone(), OperationType::Delete, author.clone());
+
+        assert_eq!(op.id, 0);
+        assert_eq!(op.target, target);
+        assert_eq!(op.kind, OperationType::Delete);
+        assert!(op.timestamp > 0);
+        assert_eq!(op.author, author);
+        assert_eq!(op.payload(), None);
+        assert!(!op.is_create());
+        assert!(op.is_delete());
+    }
+
+}

--- a/src/crdt/operation.rs
+++ b/src/crdt/operation.rs
@@ -1,0 +1,37 @@
+pub type OperationId = u128;
+pub type Author = String;
+pub type Signature = String;
+pub type Timestamp = u64;
+
+#[derive(Clone, Debug)]
+pub enum OperationType<T> {
+    Create(T),
+    Update(T),
+    Delete,
+}
+
+pub struct Operation<ContentId, T> {
+    pub id: OperationId,
+    pub target: ContentId,
+    pub kind: OperationType<T>,
+    pub timestamp: Timestamp,
+    pub author: Author,
+    pub signature: Option<Signature>,
+}
+
+impl<ContentId, T> Operation<ContentId, T> {
+    pub fn new(target: ContentId, kind: OperationType<T>, author: Author) -> Self {
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as Timestamp;
+        // todo: generate id
+        let id = 0;
+        Self { id, target, kind, timestamp, author, signature: None }
+    }
+    pub fn verify_signature(&self) -> bool {
+        true
+    }
+}
+
+


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
以下機能を追加:
- `OperationType<T>` enum を追加（Create, Update, Delete）
- `Operation<ContentId, T>` struct を追加
  - `id` (ULID)、`target`、`kind`、`timestamp`、`author` を保持
- `new` コンストラクタ実装
- ヘルパーメソッドを追加
  - `is_create()` / `is_update()` / `is_delete()`
  - `payload()`（Create/Update の中身取得）
## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
Operation構造体は、ログの記録やマージ処理の土台になっている。これを元に、CRDTの実装を行なっていく予定。

note: 
- 署名の検証などを追加するべきかを迷った
- 実際にペイロードの中身を圧縮するなどは、このOperationの作成の前に必要になると思う