### PR TITLE
Feat: Implement leveldb for saving operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
+ "tempfile",
  "ulid",
 ]
 
@@ -305,6 +306,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +324,12 @@ dependencies = [
  "cc",
  "libc",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fs2"
@@ -432,6 +449,12 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
@@ -581,6 +604,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags",
+ "errno 0.3.11",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,7 +629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0324bdbd5cba7805e1addf5d659240616960f4f1d6db4e80ad9199e52ebeb45"
 dependencies = [
  "crc",
- "errno",
+ "errno 0.2.8",
  "fs2",
  "integer-encoding",
  "rand 0.8.5",
@@ -684,6 +720,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.2",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,15 +195,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "cmake"
-version = "0.1.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,15 +216,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "crsl-lib"
 version = "0.1.0"
 dependencies = [
+ "bincode",
  "cid",
  "clap",
  "dcbor",
- "leveldb",
  "multibase",
  "multihash",
+ "rusty-leveldb",
  "serde",
  "serde_cbor",
  "serde_json",
@@ -253,12 +280,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "db-key"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b72465f46d518f6015d9cf07f7f3013a95dd6b9c2747c3d65ae0cce43929d14f"
-
-[[package]]
 name = "dcbor"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,10 +294,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "ffi-opaque"
-version = "2.0.1"
+name = "errno"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec54ac60a7f2ee9a97cad9946f9bf629a3bc6a7ae59e68983dc9318f5a54b81a"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
 
 [[package]]
 name = "getrandom"
@@ -287,7 +344,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -311,12 +368,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -349,6 +400,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,29 +425,6 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "leveldb"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32651baaaa5596b3a6e0bee625e73fd0334c167db0ea5ac68750ef9a629a2d6a"
-dependencies = [
- "db-key",
- "leveldb-sys",
- "libc",
-]
-
-[[package]]
-name = "leveldb-sys"
-version = "2.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd94a4d0242a437e5e41a27c782b69a624469ca1c4d1e5cb3c337f74a8031d4"
-dependencies = [
- "cmake",
- "ffi-opaque",
- "libc",
- "num_cpus",
 ]
 
 [[package]]
@@ -443,16 +477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,12 +523,33 @@ checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -514,7 +559,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -523,7 +577,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -531,6 +585,20 @@ name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "rusty-leveldb"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0324bdbd5cba7805e1addf5d659240616960f4f1d6db4e80ad9199e52ebeb45"
+dependencies = [
+ "crc",
+ "errno",
+ "fs2",
+ "integer-encoding",
+ "rand 0.8.5",
+ "snap",
+]
 
 [[package]]
 name = "ryu"
@@ -596,6 +664,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -653,7 +727,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand",
+ "rand 0.9.1",
  "serde",
  "web-time",
 ]
@@ -680,10 +754,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
@@ -761,6 +853,28 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +211,7 @@ dependencies = [
  "cid",
  "clap",
  "dcbor",
+ "leveldb",
  "multibase",
  "multihash",
  "serde",
@@ -243,6 +253,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "db-key"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72465f46d518f6015d9cf07f7f3013a95dd6b9c2747c3d65ae0cce43929d14f"
+
+[[package]]
 name = "dcbor"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -255,6 +271,12 @@ dependencies = [
  "thiserror",
  "unicode-normalization",
 ]
+
+[[package]]
+name = "ffi-opaque"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec54ac60a7f2ee9a97cad9946f9bf629a3bc6a7ae59e68983dc9318f5a54b81a"
 
 [[package]]
 name = "getrandom"
@@ -289,6 +311,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -343,6 +371,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "leveldb"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32651baaaa5596b3a6e0bee625e73fd0334c167db0ea5ac68750ef9a629a2d6a"
+dependencies = [
+ "db-key",
+ "leveldb-sys",
+ "libc",
+]
+
+[[package]]
+name = "leveldb-sys"
+version = "2.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd94a4d0242a437e5e41a27c782b69a624469ca1c4d1e5cb3c337f74a8031d4"
+dependencies = [
+ "cmake",
+ "ffi-opaque",
+ "libc",
+ "num_cpus",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -389,6 +440,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1.0.100"
 ulid = { version = "1.2.0", features = ["serde"] }
 rusty-leveldb = "3.0.2"
 bincode = { version = "2.0.1", features = ["serde"] }
+tempfile = "3.7.0"
 
 [[example]]
 name = "cli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ serde_cbor = "0.11.0"
 clap = { version = "4.5.11", features = ["derive"] }
 serde_json = "1.0.100"
 ulid = { version = "1.2.0", features = ["serde"] }
-leveldb = "0.8.6"
+rusty-leveldb = "3.0.2"
+bincode = { version = "2.0.1", features = ["serde"] }
 
 [[example]]
 name = "cli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ serde_cbor = "0.11.0"
 clap = { version = "4.5.11", features = ["derive"] }
 serde_json = "1.0.100"
 ulid = { version = "1.2.0", features = ["serde"] }
+leveldb = "0.8.6"
 
 [[example]]
 name = "cli"

--- a/src/crdt/mod.rs
+++ b/src/crdt/mod.rs
@@ -1,1 +1,2 @@
 pub mod operation;
+pub mod storage;

--- a/src/crdt/operation.rs
+++ b/src/crdt/operation.rs
@@ -97,7 +97,12 @@ where
     /// * `target` - ID of the content being operated on
     /// * `root_id` - ID of the genesis content
     /// * `kind` - Type of operation and its payload
-    pub fn new_with_genesis(target: ContentId, root_id: ContentId, kind: OperationType<T>, author: Author) -> Self {
+    pub fn new_with_genesis(
+        target: ContentId,
+        root_id: ContentId,
+        kind: OperationType<T>,
+        author: Author,
+    ) -> Self {
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -143,7 +148,6 @@ mod tests {
 
     #[derive(Clone, Debug, Serialize, PartialEq)]
     struct DummyPayload(String);
-
 
     #[test]
     fn test_operation_new_create() {

--- a/src/crdt/operation.rs
+++ b/src/crdt/operation.rs
@@ -51,6 +51,7 @@ impl<T> OperationType<T> {
 pub struct Operation<ContentId, T> {
     pub id: OperationId,
     pub target: ContentId,
+    pub genesis: ContentId,
     pub kind: OperationType<T>,
     pub timestamp: Timestamp,
     pub author: Author,
@@ -72,7 +73,7 @@ where
     /// # Returns
     ///
     /// A newly created operation object
-    pub fn new(target: ContentId, kind: OperationType<T>, author: Author) -> Self {
+    pub fn new(target: ContentId, genesis: ContentId, kind: OperationType<T>, author: Author) -> Self {
         let timestamp = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -81,6 +82,7 @@ where
         Self {
             id,
             target,
+            genesis,
             kind,
             timestamp,
             author,
@@ -121,11 +123,13 @@ mod tests {
     #[test]
     fn test_operation_create() {
         let target = DummyContentId("test".into());
+        let genesis = DummyContentId("genesis".into());
         let payload = DummyPayload("test".into());
         let author = "Alice".to_string();
 
         let op = Operation::new(
             target.clone(),
+            genesis.clone(),
             OperationType::Create(payload.clone()),
             author.clone(),
         );
@@ -144,11 +148,13 @@ mod tests {
     #[test]
     fn test_operation_update() {
         let target = DummyContentId("test".into());
+        let genesis = DummyContentId("genesis".into());
         let payload = DummyPayload("updated".into());
         let author = "Alice".to_string();
 
         let op = Operation::new(
             target.clone(),
+            genesis.clone(),
             OperationType::Update(payload.clone()),
             author.clone(),
         );
@@ -167,10 +173,12 @@ mod tests {
     #[test]
     fn test_operation_delete() {
         let target = DummyContentId("test".into());
+        let genesis = DummyContentId("genesis".into());
         let author = "Alice".to_string();
 
         let op = Operation::<DummyContentId, DummyPayload>::new(
             target.clone(),
+            genesis.clone(),
             OperationType::Delete,
             author.clone(),
         );

--- a/src/crdt/storage.rs
+++ b/src/crdt/storage.rs
@@ -1,9 +1,13 @@
-use leveldb::database::Database;
-use leveldb::kv::KV;
-use leveldb::options::{Options, WriteOptions, ReadOptions};
+use rusty_leveldb::{LdbIterator, Options, DB as Database};
 use serde::{Deserialize, Serialize};
 use crate::crdt::operation::Operation;
 use ulid::Ulid;
+use std::path::Path;
+use std::marker::PhantomData;
+use std::cell::RefCell;
+use bincode;
+
+
 
 pub trait OperationStorage<ContentId, T>{
     fn save_operation(&self, op: &Operation<ContentId, T>);
@@ -12,26 +16,62 @@ pub trait OperationStorage<ContentId, T>{
 }
 
 pub struct LeveldbStorage<ContentId, T> {
-    db: Database<Vec<u8>>,
-    _marker: PhantomData<ContentId>,
+    db: RefCell<Database>,
+    _marker: PhantomData<(ContentId, T)>,
 }
 
 impl<ContentId, T> LeveldbStorage<ContentId, T> {
     pub fn open<P: AsRef<Path>>(path: P) -> Self{
-        let mut opts = Options::new();
-        opts.create_if_missing(true);
+        let mut opts = Options::default();
+        opts.create_if_missing = true;
         let db = Database::open(path, opts).unwrap();
         LeveldbStorage {
-            db,
+            db: RefCell::new(db),
             _marker: PhantomData,
         }
     }
+
+    fn make_key(id: &Ulid) -> Vec<u8> {
+        let mut key = Vec::with_capacity(1 +16);
+        key.push(0x01);
+        key.extend_from_slice(id.to_bytes().as_ref());
+        key
+    }
 }
 
-impl<ContentId, T> OperationStorage<ContentId, T> for LeveldbStorage<ContentId, T> {
-    fn save_operation(&self, op: &Operation<ContentId, T>) {}
+impl<ContentId, T> OperationStorage<ContentId, T> for LeveldbStorage<ContentId, T> 
+where
+    ContentId: serde::Serialize + for<'de> serde::Deserialize<'de> + PartialEq,
+    T: serde::Serialize + for<'de> serde::Deserialize<'de>,
+{
+    fn save_operation(&self, op: &Operation<ContentId, T>) {
+        let key = Self::make_key(&op.id);
+        let value = bincode::serde::encode_to_vec(op, bincode::config::standard()).unwrap();
+        self.db.borrow_mut().put(&key, &value).unwrap();
+    }
 
-    fn load_operations(&self, content_id: &ContentId) -> Vec<Operation<ContentId, T>> {}
+    fn load_operations(&self, content_id: &ContentId) -> Vec<Operation<ContentId, T>> {
+        let mut result = Vec::new();
+        let mut iter = self.db.borrow_mut().new_iter().unwrap();
+        let mut key = Vec::new();
+        let mut value = Vec::new();
 
-    fn get_operation(&self, op_id: &Ulid) -> Option<Operation<ContentId, T>> {}
+        while iter.valid() {
+            iter.current(&mut key, &mut value);
+            if let Ok((op, _)) = bincode::serde::decode_from_slice::<Operation<ContentId, T>, _>(&value, bincode::config::standard()) {
+                if op.target == *content_id {
+                    result.push(op);
+                }
+            }
+            iter.advance();
+        }
+
+        result
+    }
+
+    fn get_operation(&self, op_id: &Ulid) -> Option<Operation<ContentId, T>> {
+        let key = Self::make_key(op_id);
+        self.db.borrow_mut().get(&key)
+        .and_then(|raw| bincode::serde::decode_from_slice::<Operation<ContentId, T>, _>(&raw, bincode::config::standard()).ok().map(|(op, _)| op))
+    }
 }

--- a/src/crdt/storage.rs
+++ b/src/crdt/storage.rs
@@ -1,0 +1,37 @@
+use leveldb::database::Database;
+use leveldb::kv::KV;
+use leveldb::options::{Options, WriteOptions, ReadOptions};
+use serde::{Deserialize, Serialize};
+use crate::crdt::operation::Operation;
+use ulid::Ulid;
+
+pub trait OperationStorage<ContentId, T>{
+    fn save_operation(&self, op: &Operation<ContentId, T>);
+    fn load_operations(&self, content_id: &ContentId) -> Vec<Operation<ContentId, T>>;
+    fn get_operation(&self, op_id: &Ulid) -> Option<Operation<ContentId, T>>;
+}
+
+pub struct LeveldbStorage<ContentId, T> {
+    db: Database<Vec<u8>>,
+    _marker: PhantomData<ContentId>,
+}
+
+impl<ContentId, T> LeveldbStorage<ContentId, T> {
+    pub fn open<P: AsRef<Path>>(path: P) -> Self{
+        let mut opts = Options::new();
+        opts.create_if_missing(true);
+        let db = Database::open(path, opts).unwrap();
+        LeveldbStorage {
+            db,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<ContentId, T> OperationStorage<ContentId, T> for LeveldbStorage<ContentId, T> {
+    fn save_operation(&self, op: &Operation<ContentId, T>) {}
+
+    fn load_operations(&self, content_id: &ContentId) -> Vec<Operation<ContentId, T>> {}
+
+    fn get_operation(&self, op_id: &Ulid) -> Option<Operation<ContentId, T>> {}
+}

--- a/src/crdt/storage.rs
+++ b/src/crdt/storage.rs
@@ -1,5 +1,4 @@
 use rusty_leveldb::{LdbIterator, Options, DB as Database};
-use serde::{Deserialize, Serialize};
 use crate::crdt::operation::Operation;
 use ulid::Ulid;
 use std::path::Path;
@@ -41,8 +40,8 @@ impl<ContentId, T> LeveldbStorage<ContentId, T> {
 
 impl<ContentId, T> OperationStorage<ContentId, T> for LeveldbStorage<ContentId, T> 
 where
-    ContentId: serde::Serialize + for<'de> serde::Deserialize<'de> + PartialEq,
-    T: serde::Serialize + for<'de> serde::Deserialize<'de>,
+    ContentId: serde::Serialize + for<'de> serde::Deserialize<'de> + PartialEq + std::fmt::Debug,
+    T: serde::Serialize + for<'de> serde::Deserialize<'de> + std::fmt::Debug,
 {
     fn save_operation(&self, op: &Operation<ContentId, T>) {
         let key = Self::make_key(&op.id);
@@ -53,13 +52,15 @@ where
     fn load_operations(&self, content_id: &ContentId) -> Vec<Operation<ContentId, T>> {
         let mut result = Vec::new();
         let mut iter = self.db.borrow_mut().new_iter().unwrap();
+        // todo: Implement efficient search methods
+        iter.seek_to_first();
         let mut key = Vec::new();
         let mut value = Vec::new();
 
         while iter.valid() {
             iter.current(&mut key, &mut value);
             if let Ok((op, _)) = bincode::serde::decode_from_slice::<Operation<ContentId, T>, _>(&value, bincode::config::standard()) {
-                if op.target == *content_id {
+                if op.genesis == *content_id {
                     result.push(op);
                 }
             }
@@ -74,4 +75,96 @@ where
         self.db.borrow_mut().get(&key)
         .and_then(|raw| bincode::serde::decode_from_slice::<Operation<ContentId, T>, _>(&raw, bincode::config::standard()).ok().map(|(op, _)| op))
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crdt::operation::{Operation, OperationType};
+    use serde::{Serialize, Deserialize};
+    use tempfile::tempdir;
+
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+    struct DummyContentId(String);
+
+    #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+    struct DummyPayload(String);
+
+    fn setup_test_storage() -> (LeveldbStorage<DummyContentId, DummyPayload>, tempfile::TempDir) {
+        let dir = tempdir().unwrap();
+        let storage = LeveldbStorage::open(dir.path());
+        (storage, dir)
+    }
+
+    #[test]
+    fn test_save_operation() {
+        let (storage, _dir) = setup_test_storage();
+        let target = DummyContentId("test".into());
+        let payload = DummyPayload("test".into());
+        let author = "Alice".to_string();
+        let op = Operation::new(target.clone(), OperationType::Create(payload.clone()), author.clone());
+
+        storage.save_operation(&op);
+
+        let retrieved_op = storage.get_operation(&op.id);
+        assert!(retrieved_op.is_some());
+        assert_eq!(retrieved_op.unwrap(), op);
+    }
+
+    #[test]
+    fn test_get_operation() {
+        let (storage, _dir) = setup_test_storage();
+        let target = DummyContentId("test".into());
+        let payload = DummyPayload("test".into());
+        let author = "Alice".to_string();
+        let op = Operation::new(target.clone(), OperationType::Create(payload.clone()), author.clone());
+        storage.save_operation(&op);
+
+        let retrieved_op = storage.get_operation(&op.id);
+
+        assert!(retrieved_op.is_some());
+        assert_eq!(retrieved_op.unwrap(), op);
+    }
+
+    #[test]
+    fn test_save_and_get_multiple_operations() {
+        let (storage, _dir) = setup_test_storage();
+        let target = DummyContentId("test".into());
+        let payload = DummyPayload("test".into());
+        let author = "Alice".to_string();
+        let op1 = Operation::new(target.clone(), OperationType::Create(payload.clone()), author.clone());
+        let op2 = Operation::new_with_genesis(target.clone(), target.clone(), OperationType::Update(payload.clone()), author.clone());
+        storage.save_operation(&op1);
+        storage.save_operation(&op2);
+
+        let retrieved_ops = storage.get_operation(&op1.id);
+        let retrieved_ops2 = storage.get_operation(&op2.id);
+
+        assert!(retrieved_ops.is_some());
+        assert_eq!(retrieved_ops.unwrap(), op1);
+        assert!(retrieved_ops2.is_some());
+        assert_eq!(retrieved_ops2.unwrap(), op2);
+    }
+
+    #[test]
+    fn test_load_operations() {
+        let (storage, _dir) = setup_test_storage();
+        let target = DummyContentId("test".into());
+        let target2 = DummyContentId("test2".into());
+        let genesis = DummyContentId("genesis".into());
+        let payload = DummyPayload("test".into());
+        let author = "Alice".to_string();
+        let op1 = Operation::new(target.clone(), OperationType::Create(payload.clone()), author.clone());
+        let op2 = Operation::new_with_genesis(target2.clone(), target.clone(), OperationType::Update(payload.clone()), author.clone());
+        let op3 = Operation::new_with_genesis(genesis.clone(), genesis.clone(), OperationType::Update(payload.clone()), author.clone());
+        storage.save_operation(&op1);
+        storage.save_operation(&op2);
+        storage.save_operation(&op3);
+
+        let retrieved_ops = storage.load_operations(&target);
+
+        assert_eq!(retrieved_ops.len(), 2);
+        assert!(retrieved_ops.contains(&op1));
+        assert!(retrieved_ops.contains(&op2));
+    }    
 }


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
以下機能を追加と修正
- operation構造体にgenesisのcontent_idの追加
  - 実際にdbから関連するoperationを取得するため
- new_with_genesis()の追加
  - 既にcontentのoperationが存在している場合、同じcidをgenesisに入れる必要がある
- levelDBの実装
  - save_operation
  - load_operations
  - get_operation
  - 実際にtraitとして、他のストレージの実装をできるように切り出した

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
operationStorageと名前を付けたが、よくよく考えるとnodeの保存にも使う必要があると思うため、もう少し変える必要があるかもしれない。ただ一旦はこのまま実装していく。