### PR TITLE
Feat: Implementation of lww-reducer

### DIFF
--- a/src/crdt/mod.rs
+++ b/src/crdt/mod.rs
@@ -1,3 +1,3 @@
 pub mod operation;
-pub mod storage;
 pub mod reducer;
+pub mod storage;

--- a/src/crdt/mod.rs
+++ b/src/crdt/mod.rs
@@ -1,2 +1,3 @@
 pub mod operation;
 pub mod storage;
+pub mod reducer;

--- a/src/crdt/reducer.rs
+++ b/src/crdt/reducer.rs
@@ -5,17 +5,17 @@ pub trait Reducer<ContentId, T> {
 }
 
 pub struct LwwReducer;
-impl<ContentId, T> Reducer<ContentId, T> for LwwReducer 
-where 
+impl<ContentId, T> Reducer<ContentId, T> for LwwReducer
+where
     T: Clone,
 {
     fn reduce(ops: &[Operation<ContentId, T>]) -> Option<T> {
-        ops.iter().max_by_key(|op| op.timestamp).and_then(|op| {
-            match &op.kind {
+        ops.iter()
+            .max_by_key(|op| op.timestamp)
+            .and_then(|op| match &op.kind {
                 OperationType::Create(v) | OperationType::Update(v) => Some(v.clone()),
                 OperationType::Delete => None,
-            }
-        })
+            })
     }
 }
 
@@ -25,14 +25,18 @@ mod tests {
     use crate::crdt::operation::{Operation, OperationType};
     use serde::{Deserialize, Serialize};
     use ulid::Ulid;
-    
+
     #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     struct DummyContentId(String);
 
     #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
     struct DummyPayload(String);
 
-    fn make_op(id: u64, ts: u64, kind: OperationType<DummyPayload>) -> Operation<DummyContentId, DummyPayload> {
+    fn make_op(
+        id: u64,
+        ts: u64,
+        kind: OperationType<DummyPayload>,
+    ) -> Operation<DummyContentId, DummyPayload> {
         Operation {
             id: Ulid::new(),
             target: DummyContentId(id.to_string()),
@@ -42,7 +46,6 @@ mod tests {
             author: "test".into(),
         }
     }
-    
 
     #[test]
     fn lww_reducer_picks_latest_update() {

--- a/src/crdt/reducer.rs
+++ b/src/crdt/reducer.rs
@@ -53,6 +53,23 @@ mod tests {
         }
     }
 
+    fn make_op_with_ulid(
+        id: u64,
+        ts: u64,
+        kind: OperationType<DummyPayload>,
+        ulid_str: &str,
+    ) -> Operation<DummyContentId, DummyPayload> {
+        let ulid = Ulid::from_string(ulid_str).unwrap();
+        Operation {
+            id: ulid,
+            target: DummyContentId(id.to_string()),
+            genesis: DummyContentId(id.to_string()),
+            kind,
+            timestamp: ts,
+            author: "test".into(),
+        }
+    }
+
     #[test]
     fn lww_reducer_picks_latest_update() {
         let op1 = make_op(1, 100, OperationType::Create(DummyPayload("A".into())));
@@ -88,9 +105,9 @@ mod tests {
 
     #[test]
     fn lww_reducer_same_timestamp() {
-        let op1 = make_op(1, 100, OperationType::Create(DummyPayload("A".into())));
-        let op2 = make_op(1, 100, OperationType::Update(DummyPayload("B".into())));
-        let op3 = make_op(1, 100, OperationType::Update(DummyPayload("C".into())));
+        let op1 = make_op_with_ulid(1, 100, OperationType::Create(DummyPayload("A".into())), "01GMTWF61FS176A96AKERBFNNX");
+        let op2 = make_op_with_ulid(1, 100, OperationType::Update(DummyPayload("B".into())), "01GMTWF7ANPDQBCMWTKGSQG4QD");
+        let op3 = make_op_with_ulid(1, 100, OperationType::Update(DummyPayload("C".into())), "01GMTWF9TZQ27MEKTAR4VWZCCT");
         let ops = vec![op1, op2, op3];
 
         let state = LwwReducer::reduce(&ops);

--- a/src/crdt/reducer.rs
+++ b/src/crdt/reducer.rs
@@ -11,7 +11,11 @@ where
 {
     fn reduce(ops: &[Operation<ContentId, T>]) -> Option<T> {
         ops.iter()
-            .max_by_key(|op| op.timestamp)
+            .max_by(|a, b| {
+                a.timestamp
+                    .cmp(&b.timestamp)
+                    .then(a.id.to_bytes().cmp(&b.id.to_bytes()))
+            })
             .and_then(|op| match &op.kind {
                 OperationType::Create(v) | OperationType::Update(v) => Some(v.clone()),
                 OperationType::Delete => None,

--- a/src/crdt/reducer.rs
+++ b/src/crdt/reducer.rs
@@ -1,0 +1,91 @@
+use crate::crdt::operation::{Operation, OperationType};
+
+pub trait Reducer<ContentId, T> {
+    fn reduce(ops: &[Operation<ContentId, T>]) -> Option<T>;
+}
+
+pub struct LwwReducer;
+impl<ContentId, T> Reducer<ContentId, T> for LwwReducer 
+where 
+    T: Clone,
+{
+    fn reduce(ops: &[Operation<ContentId, T>]) -> Option<T> {
+        ops.iter().max_by_key(|op| op.timestamp).and_then(|op| {
+            match &op.kind {
+                OperationType::Create(v) | OperationType::Update(v) => Some(v.clone()),
+                OperationType::Delete => None,
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crdt::operation::{Operation, OperationType};
+    use serde::{Deserialize, Serialize};
+    use ulid::Ulid;
+    
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+    struct DummyContentId(String);
+
+    #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+    struct DummyPayload(String);
+
+    fn make_op(id: u64, ts: u64, kind: OperationType<DummyPayload>) -> Operation<DummyContentId, DummyPayload> {
+        Operation {
+            id: Ulid::new(),
+            target: DummyContentId(id.to_string()),
+            genesis: DummyContentId(id.to_string()),
+            kind,
+            timestamp: ts,
+            author: "test".into(),
+        }
+    }
+    
+
+    #[test]
+    fn lww_reducer_picks_latest_update() {
+        let op1 = make_op(1, 100, OperationType::Create(DummyPayload("A".into())));
+        let op2 = make_op(1, 200, OperationType::Update(DummyPayload("B".into())));
+        let op3 = make_op(1, 150, OperationType::Update(DummyPayload("C".into())));
+        let ops = vec![op1, op2.clone(), op3];
+
+        let state = LwwReducer::reduce(&ops);
+        println!("state: {:?}", state);
+
+        assert_eq!(state, Some(DummyPayload("B".into())));
+    }
+
+    #[test]
+    fn lww_reducer_handles_delete() {
+        let op1 = make_op(1, 100, OperationType::Create(DummyPayload("A".into())));
+        let del = make_op(1, 200, OperationType::Delete);
+        let ops = vec![op1, del.clone()];
+
+        let state = LwwReducer::reduce(&ops);
+
+        assert_eq!(state, None);
+    }
+
+    #[test]
+    fn lww_reducer_empty_ops() {
+        let ops: Vec<Operation<DummyContentId, DummyPayload>> = vec![];
+
+        let state = LwwReducer::reduce(&ops);
+
+        assert_eq!(state, None);
+    }
+
+    #[test]
+    fn lww_reducer_same_timestamp() {
+        let op1 = make_op(1, 100, OperationType::Create(DummyPayload("A".into())));
+        let op2 = make_op(1, 100, OperationType::Update(DummyPayload("B".into())));
+        let op3 = make_op(1, 100, OperationType::Update(DummyPayload("C".into())));
+        let ops = vec![op1, op2, op3];
+
+        let state = LwwReducer::reduce(&ops);
+
+        assert_eq!(state, Some(DummyPayload("C".into())));
+    }
+}

--- a/src/crdt/reducer.rs
+++ b/src/crdt/reducer.rs
@@ -4,6 +4,8 @@ pub trait Reducer<ContentId, T> {
     fn reduce(ops: &[Operation<ContentId, T>]) -> Option<T>;
 }
 
+/// Last-Write-Wins reducer: picks the operation with the highest timestamp,
+/// breaking ties by ULID order.
 pub struct LwwReducer;
 impl<ContentId, T> Reducer<ContentId, T> for LwwReducer
 where

--- a/src/crdt/reducer.rs
+++ b/src/crdt/reducer.rs
@@ -105,9 +105,24 @@ mod tests {
 
     #[test]
     fn lww_reducer_same_timestamp() {
-        let op1 = make_op_with_ulid(1, 100, OperationType::Create(DummyPayload("A".into())), "01GMTWF61FS176A96AKERBFNNX");
-        let op2 = make_op_with_ulid(1, 100, OperationType::Update(DummyPayload("B".into())), "01GMTWF7ANPDQBCMWTKGSQG4QD");
-        let op3 = make_op_with_ulid(1, 100, OperationType::Update(DummyPayload("C".into())), "01GMTWF9TZQ27MEKTAR4VWZCCT");
+        let op1 = make_op_with_ulid(
+            1,
+            100,
+            OperationType::Create(DummyPayload("A".into())),
+            "01GMTWF61FS176A96AKERBFNNX",
+        );
+        let op2 = make_op_with_ulid(
+            1,
+            100,
+            OperationType::Update(DummyPayload("B".into())),
+            "01GMTWF7ANPDQBCMWTKGSQG4QD",
+        );
+        let op3 = make_op_with_ulid(
+            1,
+            100,
+            OperationType::Update(DummyPayload("C".into())),
+            "01GMTWF9TZQ27MEKTAR4VWZCCT",
+        );
         let ops = vec![op1, op2, op3];
 
         let state = LwwReducer::reduce(&ops);


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
このPRでは、CRDT システム向けの Last-Write-Wins (LWW) Reducer を実装した。LWW Reducer は最新のタイムスタンプを持つ操作を選択することで競合を解決し、シンプルかつ予測可能な状態収束を可能にする。
主な変更点:
- 汎用的な reduce メソッドを持つ Reducer トレイトの追加
- 最新の操作を選択する LwwReducer の実装
  - timestampによる順序づけ
  - 仮に同じ場合、ulidによる順序づけ
- testの追加

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
使用例:
```rust
// 対象コンテンツに対する操作のリストを取得
let operations = storage.load_operations(&content_id);

// LWW Reducerを使って最新の状態を取得
let current_state = LwwReducer::reduce(&operations);
```
フェーズ1では、lww方式を使っているが、差分などの実装はここに追加していくイメージをしている。
今回は差分などの計算や圧縮は含まれていないため、automergeライブラリーは不使用。この先もしかしたら使用する可能性はあるが、実際に暗号化したまま計算など考えると、もしかしたら独自で実装した方が良い可能性はある。