### PR TITLE
Feat: Implementation of node storage using levelDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/test_db

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -43,7 +43,9 @@ impl MockStorage {
     fn new() -> Self {
         if let Ok(data) = std::fs::read_to_string("nodes.json") {
             if let Ok(nodes) = serde_json::from_str(&data) {
-                return Self { nodes: RefCell::new(nodes) };
+                return Self {
+                    nodes: RefCell::new(nodes),
+                };
             }
         }
         Self {
@@ -61,7 +63,9 @@ impl NodeStorage<String, BTreeMap<String, String>> for MockStorage {
     }
 
     fn put(&self, node: &Node<String, BTreeMap<String, String>>) {
-        self.nodes.borrow_mut().insert(node.content_id(), node.clone());
+        self.nodes
+            .borrow_mut()
+            .insert(node.content_id(), node.clone());
     }
 
     fn delete(&self, content_id: &Cid) {

--- a/src/dasl/node.rs
+++ b/src/dasl/node.rs
@@ -21,7 +21,7 @@ const RAW_CODE: u64 = 0x55;
 /// * `parents` - A vector of content ids (Content Identifiers) pointing to parent entries.
 /// * `timestamp` - Unix timestamp representing when the entry was created.
 /// * `metadata` - Additional information about the entry (e.g., author, tags, or other attributes).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(bound = "P: Serialize + for<'a> Deserialize<'a>, M: Serialize + for<'a> Deserialize<'a>")]
 pub struct Node<P, M = BTreeMap<String, String>> {
     pub payload: P,
@@ -132,7 +132,6 @@ mod tests {
     use std::collections::BTreeMap;
 
     fn create_test_content_id(data: &[u8]) -> Cid {
-        use multihash::Multihash;
         let code = 0x12;
         let digest = Multihash::<64>::wrap(code, data).unwrap();
         Cid::new_v1(0x55, digest)

--- a/src/graph/dag.rs
+++ b/src/graph/dag.rs
@@ -170,9 +170,9 @@ mod tests {
             ))
         }
 
-        fn put(&mut self, _node: &Node<P, M>) {}
+        fn put(&self, _node: &Node<P, M>) {}
 
-        fn delete(&mut self, _content_id: &Cid) {}
+        fn delete(&self, _content_id: &Cid) {}
     }
 
     fn create_test_content_id(data: &[u8]) -> Cid {

--- a/src/graph/storage.rs
+++ b/src/graph/storage.rs
@@ -1,9 +1,142 @@
 use crate::dasl::node::Node;
 use cid::Cid;
+use rusty_leveldb::{DB as Database, Options};
+use std::cell::RefCell;
+use std::path::Path;
+use bincode;
 
 // todo: error handling
 pub trait NodeStorage<P, M> {
     fn get(&self, content_id: &Cid) -> Option<Node<P, M>>;
-    fn put(&mut self, node: &Node<P, M>);
-    fn delete(&mut self, content_id: &Cid);
+    fn put(&self, node: &Node<P, M>);
+    fn delete(&self, content_id: &Cid);
 }
+
+pub struct LeveldbNodeStorage<P, M> {
+    db: RefCell<Database>,
+    _marker: std::marker::PhantomData<(P, M)>,
+}
+
+impl<P, M> LeveldbNodeStorage<P, M> {
+    pub fn open<Pth: AsRef<Path>>(path: Pth) -> Self {
+        let opts = Options { create_if_missing: true, ..Default::default() };
+        let db = Database::open(path, opts).unwrap();
+        Self { db: RefCell::new(db), _marker: std::marker::PhantomData }
+    }
+    fn make_key(cid: &Cid) -> Vec<u8> {
+        let mut v = Vec::with_capacity(1 + cid.to_bytes().len());
+        v.push(0x10);
+        v.extend_from_slice(&cid.to_bytes());
+        v
+    }
+}
+
+impl<P, M> NodeStorage<P, M> for LeveldbNodeStorage<P, M>
+where
+    P: serde::Serialize + for<'de> serde::Deserialize<'de> + Clone,
+    M: serde::Serialize + for<'de> serde::Deserialize<'de> + Clone,
+{
+    fn get(&self, cid: &Cid) -> Option<Node<P, M>> {
+        self.db.borrow_mut().get(&Self::make_key(cid))
+            .and_then(|raw| {
+                bincode::serde::decode_from_slice::<Node<P, M>, _>(
+                    &raw,
+                    bincode::config::standard(),
+                )
+                .ok()
+                .map(|(node, _)| node)
+            })
+    }
+
+    fn put(&self, node: &Node<P, M>) {
+        if let Ok(val) = bincode::serde::encode_to_vec(node, bincode::config::standard()) {
+            let _ = self.db.borrow_mut().put(&Self::make_key(&node.content_id()), &val);
+        }
+    }
+
+    fn delete(&self, cid: &Cid) {
+        let _ = self.db.borrow_mut().delete(&Self::make_key(cid));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dasl::node::Node;
+    use tempfile::tempdir;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn create_test_node(payload: &str) -> Node<String, String> {
+        let timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        Node::new(payload.to_string(), vec![], timestamp, "metadata".to_string())
+    }
+
+    #[test]
+    fn test_put_and_get() {
+        let temp_dir = tempdir().unwrap();
+        let storage = LeveldbNodeStorage::<String, String>::open(temp_dir.path());
+        
+        let node = create_test_node("test-payload");
+        let cid = node.content_id();
+        
+        storage.put(&node);
+        let retrieved_node = storage.get(&cid);
+        assert!(retrieved_node.is_some());
+        
+        let retrieved_node = retrieved_node.unwrap();
+        assert_eq!(retrieved_node.content_id(), node.content_id());
+        assert_eq!(retrieved_node.payload(), node.payload());
+        assert_eq!(retrieved_node.metadata(), node.metadata());
+    }
+    
+    #[test]
+    fn test_delete() {
+        let temp_dir = tempdir().unwrap();
+        let storage = LeveldbNodeStorage::<String, String>::open(temp_dir.path());
+        
+        let node = create_test_node("delete-test");
+        let cid = node.content_id();
+        storage.put(&node);
+        assert!(storage.get(&cid).is_some());
+
+        storage.delete(&cid);
+
+        assert!(storage.get(&cid).is_none());
+    }
+    
+    #[test]
+    fn test_multiple_nodes() {
+        let temp_dir = tempdir().unwrap();
+        let storage = LeveldbNodeStorage::<String, String>::open(temp_dir.path());
+        let node1 = create_test_node("payload-1");
+        let node2 = create_test_node("payload-2");
+        let node3 = create_test_node("payload-3");
+        
+        storage.put(&node1);
+        storage.put(&node2);
+        storage.put(&node3);
+        
+        assert!(storage.get(&node1.content_id()).is_some());
+        assert!(storage.get(&node2.content_id()).is_some());
+        assert!(storage.get(&node3.content_id()).is_some());
+        
+        assert_eq!(storage.get(&node1.content_id()).unwrap().payload(), "payload-1");
+        assert_eq!(storage.get(&node2.content_id()).unwrap().payload(), "payload-2");
+        assert_eq!(storage.get(&node3.content_id()).unwrap().payload(), "payload-3");
+    }
+    
+    #[test]
+    fn test_nonexistent_node() {
+        let temp_dir = tempdir().unwrap();
+        let storage = LeveldbNodeStorage::<String, String>::open(temp_dir.path());
+        
+        let node = create_test_node("nonexistent");
+        let cid = node.content_id();
+        
+        assert!(storage.get(&cid).is_none());
+    }
+}
+

--- a/src/graph/storage.rs
+++ b/src/graph/storage.rs
@@ -1,9 +1,9 @@
 use crate::dasl::node::Node;
+use bincode;
 use cid::Cid;
-use rusty_leveldb::{DB as Database, Options};
+use rusty_leveldb::{Options, DB as Database};
 use std::cell::RefCell;
 use std::path::Path;
-use bincode;
 
 // todo: error handling
 pub trait NodeStorage<P, M> {
@@ -19,9 +19,15 @@ pub struct LeveldbNodeStorage<P, M> {
 
 impl<P, M> LeveldbNodeStorage<P, M> {
     pub fn open<Pth: AsRef<Path>>(path: Pth) -> Self {
-        let opts = Options { create_if_missing: true, ..Default::default() };
+        let opts = Options {
+            create_if_missing: true,
+            ..Default::default()
+        };
         let db = Database::open(path, opts).unwrap();
-        Self { db: RefCell::new(db), _marker: std::marker::PhantomData }
+        Self {
+            db: RefCell::new(db),
+            _marker: std::marker::PhantomData,
+        }
     }
     fn make_key(cid: &Cid) -> Vec<u8> {
         let mut v = Vec::with_capacity(1 + cid.to_bytes().len());
@@ -37,7 +43,9 @@ where
     M: serde::Serialize + for<'de> serde::Deserialize<'de> + Clone,
 {
     fn get(&self, cid: &Cid) -> Option<Node<P, M>> {
-        self.db.borrow_mut().get(&Self::make_key(cid))
+        self.db
+            .borrow_mut()
+            .get(&Self::make_key(cid))
             .and_then(|raw| {
                 bincode::serde::decode_from_slice::<Node<P, M>, _>(
                     &raw,
@@ -50,7 +58,10 @@ where
 
     fn put(&self, node: &Node<P, M>) {
         if let Ok(val) = bincode::serde::encode_to_vec(node, bincode::config::standard()) {
-            let _ = self.db.borrow_mut().put(&Self::make_key(&node.content_id()), &val);
+            let _ = self
+                .db
+                .borrow_mut()
+                .put(&Self::make_key(&node.content_id()), &val);
         }
     }
 
@@ -63,40 +74,45 @@ where
 mod tests {
     use super::*;
     use crate::dasl::node::Node;
-    use tempfile::tempdir;
     use std::time::{SystemTime, UNIX_EPOCH};
+    use tempfile::tempdir;
 
     fn create_test_node(payload: &str) -> Node<String, String> {
         let timestamp = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
-        Node::new(payload.to_string(), vec![], timestamp, "metadata".to_string())
+        Node::new(
+            payload.to_string(),
+            vec![],
+            timestamp,
+            "metadata".to_string(),
+        )
     }
 
     #[test]
     fn test_put_and_get() {
         let temp_dir = tempdir().unwrap();
         let storage = LeveldbNodeStorage::<String, String>::open(temp_dir.path());
-        
+
         let node = create_test_node("test-payload");
         let cid = node.content_id();
-        
+
         storage.put(&node);
         let retrieved_node = storage.get(&cid);
         assert!(retrieved_node.is_some());
-        
+
         let retrieved_node = retrieved_node.unwrap();
         assert_eq!(retrieved_node.content_id(), node.content_id());
         assert_eq!(retrieved_node.payload(), node.payload());
         assert_eq!(retrieved_node.metadata(), node.metadata());
     }
-    
+
     #[test]
     fn test_delete() {
         let temp_dir = tempdir().unwrap();
         let storage = LeveldbNodeStorage::<String, String>::open(temp_dir.path());
-        
+
         let node = create_test_node("delete-test");
         let cid = node.content_id();
         storage.put(&node);
@@ -106,7 +122,7 @@ mod tests {
 
         assert!(storage.get(&cid).is_none());
     }
-    
+
     #[test]
     fn test_multiple_nodes() {
         let temp_dir = tempdir().unwrap();
@@ -114,29 +130,37 @@ mod tests {
         let node1 = create_test_node("payload-1");
         let node2 = create_test_node("payload-2");
         let node3 = create_test_node("payload-3");
-        
+
         storage.put(&node1);
         storage.put(&node2);
         storage.put(&node3);
-        
+
         assert!(storage.get(&node1.content_id()).is_some());
         assert!(storage.get(&node2.content_id()).is_some());
         assert!(storage.get(&node3.content_id()).is_some());
-        
-        assert_eq!(storage.get(&node1.content_id()).unwrap().payload(), "payload-1");
-        assert_eq!(storage.get(&node2.content_id()).unwrap().payload(), "payload-2");
-        assert_eq!(storage.get(&node3.content_id()).unwrap().payload(), "payload-3");
+
+        assert_eq!(
+            storage.get(&node1.content_id()).unwrap().payload(),
+            "payload-1"
+        );
+        assert_eq!(
+            storage.get(&node2.content_id()).unwrap().payload(),
+            "payload-2"
+        );
+        assert_eq!(
+            storage.get(&node3.content_id()).unwrap().payload(),
+            "payload-3"
+        );
     }
-    
+
     #[test]
     fn test_nonexistent_node() {
         let temp_dir = tempdir().unwrap();
         let storage = LeveldbNodeStorage::<String, String>::open(temp_dir.path());
-        
+
         let node = create_test_node("nonexistent");
         let cid = node.content_id();
-        
+
         assert!(storage.get(&cid).is_none());
     }
 }
-


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
DAGグラフのストレージレイヤー実装を行なった。このPRでは以下の変更を行った：
- NodeStorage トレイトを定義し、グラフノードの永続化に必要な基本操作（取得・保存・削除）を抽象化
- LevelDBを使用した LeveldbNodeStorage の実装
  -  `fn get()`
  - `fn put()`
  - `fn delete()`
- テストケースの追加

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
- エラー処理について追加する必要がある
- 他のストレージの対応も含めて考える必要があるかも