### PR TITLE
Feat: implement repo method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "dcbor"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd7515d6680292a81c11bd3371c7e553c0780371d932d6e6797e7e99ee38aff"
+checksum = "402f083d3c2daef249d4c06ef827c8b743ab88536f73dae52201f4de5abb0354"
 dependencies = [
  "chrono",
  "half 2.6.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,7 @@ dependencies = [
  "multihash",
  "rusty-leveldb",
  "serde",
+ "serde_bytes",
  "serde_cbor",
  "serde_json",
  "tempfile",
@@ -653,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.15"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
+checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 rust-version = "1.79"
 
 [dependencies]
-dcbor = "0.18.0"
+dcbor = "0.19.1"
 cid = { version = "0.11.1", features = ["serde"] }
 multihash = "0.19.3"
 multibase = "0.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ ulid = { version = "1.2.0", features = ["serde"] }
 rusty-leveldb = "3.0.2"
 bincode = { version = "2.0.1", features = ["serde"] }
 tempfile = "3.7.0"
+serde_bytes = "0.11.17"
 
 [[example]]
-name = "cli"
-path = "examples/cli.rs"
+name = "content_versioning"
+path = "examples/content_versioning.rs"

--- a/examples/content_versioning.rs
+++ b/examples/content_versioning.rs
@@ -1,0 +1,126 @@
+//! examples/content_versioning.rs
+//!
+//! 1. Create  (v1)
+//! 2. Update  (v2)
+//! 3. Update  (v3a)  ← branch A
+//! 4. Update  (v3b)  ← branch B
+//! 5. Merge   (v4)   ← parents = [v3a, v3b]
+
+use crsl_lib::{
+    crdt::{
+        operation::{Operation, OperationType},
+        reducer::LwwReducer,
+        crdt_state::CrdtState,
+        storage::LeveldbStorage as OpStore,
+    },
+    graph::{
+        storage::LeveldbNodeStorage as NodeStorage,
+        dag::{DagGraph},
+    },
+};
+use tempfile::tempdir;
+
+type Content = String;
+type Store = OpStore<String, Content>;
+type ContentState = CrdtState<String, Content, Store, LwwReducer>;
+
+fn main() {
+    let tmp       = tempdir().expect("tmp dir");
+    let op_store  = OpStore::open(tmp.path().join("ops"));
+    let node_store = NodeStorage::open(tmp.path().join("nodes"));
+    let state = ContentState::new(op_store);
+    let mut _dag   = DagGraph::<_, Content, ()>::new(node_store);
+    
+    let content_id = "content1".to_string();
+    let create_op = Operation::new(
+        content_id.clone(),
+        OperationType::Create("Initial content".to_string()),
+        "user1".to_string(),
+    );
+    
+    // Apply the create operation
+    state.apply(create_op);
+
+    // ────────────────────────────────────────────────
+    // 1. Create  (v1)
+    // ────────────────────────────────────────────────
+    let cid = "content1".to_owned();
+    let create_op = Operation::new(
+        cid.clone(),
+        OperationType::Create("Initial content".into()),
+        "user1".into(),
+    );
+    state.apply(create_op.clone());
+    // todo: implement commit to dag
+    // let parent = dag.latest_head(&op.target);
+    // dag.add_node(
+    //     op.payload().unwrap().clone(),
+    //     parent.into_iter().collect(),
+    //     (),
+    // ).unwrap();
+
+    // ────────────────────────────────────────────────
+    // 2. Update  (v2)    ← HEAD = v1
+    // ────────────────────────────────────────────────
+    // todo: find the latest root_id or maybe get root_id from latest node??
+    let op_v2 = Operation::new_with_genesis(
+        cid.clone(),
+        cid.clone(),
+        OperationType::Update("Updated content".into()),
+        "user1".into(),
+    );
+    state.apply(op_v2);
+    // todo: implement commit to dag
+    // let parent = dag.latest_head(&op.target);
+    // dag.add_node(
+    //     op.payload().unwrap().clone(),
+    //     parent.into_iter().collect(),
+    //     (),
+    // ).unwrap();
+
+    // ────────────────────────────────────────────────
+    // 3. Update  (v3a)  ← branch A
+    // ────────────────────────────────────────────────
+    let op_v3a = Operation::new_with_genesis(
+        cid.clone(),
+        content_id.clone(),
+        OperationType::Update("Updated content 2".to_string()),
+        "user2".to_string(),
+    );
+    state.apply(op_v3a);
+    // todo: commit to dag
+    // let parent = dag.latest_head(&op.target);
+    // dag.add_node(
+    //     op.payload().unwrap().clone(),
+    //     parent.into_iter().collect(),
+    //     (),
+    // ).unwrap();
+
+    // ────────────────────────────────────────────────
+    // 4. Update  (v3b)   ← branch B (parent = v2)
+    // ────────────────────────────────────────────────
+    let op_v3b = Operation::new_with_genesis(
+        cid.clone(),
+        content_id.clone(),
+        OperationType::Update("Updated content B".into()),
+        "userB".into(),
+    );
+    state.apply(op_v3b);
+    // todo: commit to dag
+    // let parent = dag.latest_head(&op.target);
+    // dag.add_node(
+    //     op.payload().unwrap().clone(),
+    //     parent.into_iter().collect(),
+    //     (),
+    // ).unwrap();
+
+    // ────────────────────────────────────────────────
+    // 6. Show version history
+    // ────────────────────────────────────────────────
+    // let history = topo_sort(&dag);
+    // println!("--- Version history ---");
+    // for (i, c) in history.iter().enumerate() {
+    //     println!("v{}  {}", i + 1, short(c));
+    // }
+    
+}

--- a/examples/content_versioning.rs
+++ b/examples/content_versioning.rs
@@ -8,15 +8,12 @@
 
 use crsl_lib::{
     crdt::{
+        crdt_state::CrdtState,
         operation::{Operation, OperationType},
         reducer::LwwReducer,
-        crdt_state::CrdtState,
         storage::LeveldbStorage as OpStore,
     },
-    graph::{
-        storage::LeveldbNodeStorage as NodeStorage,
-        dag::{DagGraph},
-    },
+    graph::{dag::DagGraph, storage::LeveldbNodeStorage as NodeStorage},
 };
 use tempfile::tempdir;
 
@@ -25,19 +22,19 @@ type Store = OpStore<String, Content>;
 type ContentState = CrdtState<String, Content, Store, LwwReducer>;
 
 fn main() {
-    let tmp       = tempdir().expect("tmp dir");
-    let op_store  = OpStore::open(tmp.path().join("ops"));
+    let tmp = tempdir().expect("tmp dir");
+    let op_store = OpStore::open(tmp.path().join("ops"));
     let node_store = NodeStorage::open(tmp.path().join("nodes"));
     let state = ContentState::new(op_store);
-    let mut _dag   = DagGraph::<_, Content, ()>::new(node_store);
-    
+    let mut _dag = DagGraph::<_, Content, ()>::new(node_store);
+
     let content_id = "content1".to_string();
     let create_op = Operation::new(
         content_id.clone(),
         OperationType::Create("Initial content".to_string()),
         "user1".to_string(),
     );
-    
+
     // Apply the create operation
     state.apply(create_op);
 
@@ -122,5 +119,4 @@ fn main() {
     // for (i, c) in history.iter().enumerate() {
     //     println!("v{}  {}", i + 1, short(c));
     // }
-    
 }

--- a/src/crdt/reducer.rs
+++ b/src/crdt/reducer.rs
@@ -78,7 +78,6 @@ mod tests {
         let ops = vec![op1, op2.clone(), op3];
 
         let state = LwwReducer::reduce(&ops);
-        println!("state: {:?}", state);
 
         assert_eq!(state, Some(DummyPayload("B".into())));
     }

--- a/src/dasl/node.rs
+++ b/src/dasl/node.rs
@@ -75,7 +75,7 @@ where
     /// # Errors
     /// Returns a NodeError if serialization fails
     pub fn to_bytes(&self) -> Vec<u8> {
-        serde_cbor::to_vec(self).unwrap()
+        serde_cbor::to_vec(self).expect("Failed to serialize node")
     }
 
     /// Deserializes a Node from bytes
@@ -89,7 +89,7 @@ where
     /// # Errors
     /// Returns a NodeError if deserialization fails
     pub fn from_bytes(buf: &[u8]) -> Self {
-        serde_cbor::from_slice(buf).unwrap()
+        serde_cbor::from_slice(buf).expect("Failed to deserialize node")
     }
 
     /// Verifies the integrity of the node by comparing the calculated content id with the expected content id

--- a/src/graph/dag.rs
+++ b/src/graph/dag.rs
@@ -1,7 +1,7 @@
 use crate::dasl::node::Node;
 use crate::graph::storage::NodeStorage;
 use cid::Cid;
-use std::collections::{HashSet, HashMap};
+use std::collections::{HashMap, HashSet};
 use std::marker::PhantomData;
 use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/src/graph/dag.rs
+++ b/src/graph/dag.rs
@@ -1,7 +1,7 @@
 use crate::dasl::node::Node;
 use crate::graph::storage::NodeStorage;
 use cid::Cid;
-use std::collections::HashSet;
+use std::collections::{HashSet, HashMap};
 use std::marker::PhantomData;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -26,6 +26,7 @@ where
     S: NodeStorage<P, M>,
 {
     pub storage: S,
+    pub heads: HashMap<String, Cid>,
     _p_marker: PhantomData<P>,
     _m_marker: PhantomData<M>,
 }
@@ -39,6 +40,7 @@ where
     pub fn new(storage: S) -> Self {
         Self {
             storage,
+            heads: HashMap::new(),
             _p_marker: PhantomData,
             _m_marker: PhantomData,
         }
@@ -129,6 +131,14 @@ where
             }
         }
         Ok(false)
+    }
+
+    pub fn latest_head(&self, content_id: &Cid) -> Option<Cid> {
+        self.heads.get(content_id.to_string().as_str()).cloned()
+    }
+
+    pub fn set_head(&mut self, content_id: &Cid, head: Cid) {
+        self.heads.insert(content_id.to_string(), head);
     }
 }
 
@@ -267,5 +277,44 @@ mod tests {
         let result = dag.would_create_cycle(&cid_e, &cid_a);
         assert!(result.is_ok());
         assert!(result.unwrap(), "true");
+    }
+
+    #[test]
+    fn test_latest_head() {
+        let mut dag = DagGraph::<_, String, BTreeMap<String, String>>::new(MockStorage::new());
+        let cid_a = create_test_content_id(b"node_a");
+        let cid_b = create_test_content_id(b"node_b");
+
+        dag.set_head(&cid_a, cid_b);
+        let head = dag.latest_head(&cid_a);
+
+        assert!(head.is_some());
+        assert_eq!(head.unwrap(), cid_b);
+    }
+
+    #[test]
+    fn test_empty_latest_head() {
+        let dag = DagGraph::<_, String, BTreeMap<String, String>>::new(MockStorage::new());
+        let cid_a = create_test_content_id(b"node_a");
+
+        let head = dag.latest_head(&cid_a);
+
+        assert!(head.is_none());
+    }
+
+    #[test]
+    fn test_multiple_heads() {
+        let mut dag = DagGraph::<_, String, BTreeMap<String, String>>::new(MockStorage::new());
+        let cid_a = create_test_content_id(b"node_a");
+        let cid_b = create_test_content_id(b"node_b");
+        let cid_c = create_test_content_id(b"node_c");
+        dag.set_head(&cid_a, cid_b);
+        dag.set_head(&cid_a, cid_c);
+
+        let head = dag.latest_head(&cid_a);
+        println!("head: {:?}", head);
+
+        assert!(head.is_some());
+        assert!(head.unwrap() == cid_c);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,3 +2,4 @@ pub mod crdt;
 pub mod dasl;
 pub mod graph;
 pub mod masl;
+pub mod repo;

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,0 +1,178 @@
+use crate:: {
+    crdt::{crdt_state::CrdtState, operation::{Operation, OperationType}, reducer::LwwReducer, storage::OperationStorage},
+    graph::{dag::DagGraph, storage::NodeStorage},
+};
+use cid::Cid;
+use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
+
+pub struct Repo<OpStore, NodeStore, Payload> 
+where 
+    OpStore: OperationStorage<Cid, Payload>,
+    NodeStore: NodeStorage<Payload, ()>,
+    Payload: Clone + Serialize + for<'de> Deserialize<'de> + Debug,
+{
+    pub state: CrdtState<Cid, Payload, OpStore, LwwReducer>,
+    pub dag: DagGraph<NodeStore, Payload, ()>,
+}
+
+impl<OpStore, NodeStore, Payload> Repo<OpStore, NodeStore, Payload>
+where 
+    OpStore: OperationStorage<Cid, Payload>,
+    NodeStore: NodeStorage<Payload, ()>,
+    Payload: Clone + Serialize + for<'de> Deserialize<'de> + Debug,
+{
+    pub fn new(state: CrdtState<Cid, Payload, OpStore, LwwReducer>,
+        dag: DagGraph<NodeStore, Payload, ()>) -> Self {
+        Self { state, dag }
+    }
+
+    pub fn commit_operation(&mut self, op: Operation<Cid, Payload>) -> Cid {
+        self.state.apply(op.clone());
+        let parents = self
+            .dag
+            .latest_head(&op.target)
+            .into_iter()
+            .collect::<Vec<_>>();
+        
+        let cid = match &op.kind {
+            OperationType::Create(payload) | OperationType::Update(payload) => {
+                self.dag
+                    .add_node(payload.clone(), parents, ())
+                    .expect("add node")
+            }
+            OperationType::Delete => {
+                // For delete operations, we create a node with the last known payload
+                // This ensures we maintain the DAG structure while marking the content as deleted
+                let last_payload = self.state.get_state(&op.target)
+                    .expect("content must exist for delete operation");
+                self.dag
+                    .add_node(last_payload, parents, ())
+                    .expect("add node")
+            }
+        };
+        
+        self.dag.set_head(&op.target, cid);
+        cid
+    }
+
+    pub fn latest(&self, target: &Cid) -> Option<Cid> {
+        self.dag.latest_head(target)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crdt::operation::{Operation, OperationType};
+    use crate::crdt::storage::LeveldbStorage;
+    use crate::graph::storage::LeveldbNodeStorage;
+    use tempfile::tempdir;
+    use ulid::Ulid;
+
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+    #[serde(transparent)]
+    struct TestPayload(String);
+
+    type TestRepo = Repo<LeveldbStorage<Cid, TestPayload>, LeveldbNodeStorage<TestPayload, ()>, TestPayload>;
+
+    fn setup_test_repo() -> (TestRepo, tempfile::TempDir) {
+        let dir = tempdir().unwrap();
+        let op_storage = LeveldbStorage::open(dir.path().join("ops"));
+        let node_storage = LeveldbNodeStorage::open(dir.path().join("nodes"));
+        let state = CrdtState::new(op_storage);
+        let dag = DagGraph::new(node_storage);
+        let repo = Repo::new(state, dag);
+        (repo, dir)
+    }
+
+    fn make_test_operation(target: Cid, kind: OperationType<TestPayload>) -> Operation<Cid, TestPayload> {
+        Operation {
+            id: Ulid::new(),
+            target,
+            genesis: target,
+            kind,
+            timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as u64,
+            author: "test".to_string(),
+        }
+    }
+    fn make_test_operation_with_genesis(target: Cid, genesis: Cid, kind: OperationType<TestPayload>) -> Operation<Cid, TestPayload> {
+        Operation {
+            id: Ulid::new(),
+            target,
+            genesis,
+            kind,
+            timestamp: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis() as u64,
+            author: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn test_create_operation() {
+        let (mut repo, _) = setup_test_repo();
+        let target = Cid::new_v1(0x55, multihash::Multihash::<64>::wrap(0x12, b"test").unwrap());
+        let payload = TestPayload("test content".to_string());
+        let op = make_test_operation(target, OperationType::Create(payload.clone()));
+
+        let cid = repo.commit_operation(op);
+
+        assert!(repo.latest(&target).is_some());
+        assert_eq!(repo.latest(&target).unwrap(), cid);
+    }
+
+    #[test]
+    fn test_update_operation() {
+        let (mut repo, _) = setup_test_repo();
+        let target = Cid::new_v1(0x55, multihash::Multihash::<64>::wrap(0x12, b"test").unwrap());
+        let create_op = make_test_operation(target, OperationType::Create(TestPayload("initial".to_string())));
+        let create_cid = repo.commit_operation(create_op);
+
+        let update_op = make_test_operation_with_genesis(target, create_cid, OperationType::Update(TestPayload("updated".to_string())));
+        let update_cid = repo.commit_operation(update_op);
+
+        assert!(repo.latest(&target).is_some());
+        assert_eq!(repo.latest(&target).unwrap(), update_cid);
+        assert_ne!(create_cid, update_cid);
+    }
+
+    #[test]
+    fn test_delete_operation() {
+        let (mut repo, _) = setup_test_repo();
+        let target = Cid::new_v1(0x55, multihash::Multihash::<64>::wrap(0x12, b"test").unwrap());
+        let create_op = make_test_operation(target, OperationType::Create(TestPayload("initial".to_string())));
+        let create_cid = repo.commit_operation(create_op);
+
+        let delete_op = make_test_operation_with_genesis(target, create_cid, OperationType::Delete);
+        let delete_cid = repo.commit_operation(delete_op);
+
+        assert!(repo.latest(&target).is_some());
+        assert_eq!(repo.latest(&target).unwrap(), delete_cid);
+        assert_ne!(create_cid, delete_cid);
+    }
+
+    #[test]
+    fn test_multiple_targets() {
+        let (mut repo, _) = setup_test_repo();
+        let target1 = Cid::new_v1(0x55, multihash::Multihash::<64>::wrap(0x12, b"test1").unwrap());
+        let target2 = Cid::new_v1(0x55, multihash::Multihash::<64>::wrap(0x12, b"test2").unwrap());
+        
+        // Create two different targets
+        let create1_op = make_test_operation(target1, OperationType::Create(TestPayload("target1".to_string())));
+        let create1_cid = repo.commit_operation(create1_op);
+
+        let create2_op = make_test_operation(target2, OperationType::Create(TestPayload("target2".to_string())));
+        let create2_cid = repo.commit_operation(create2_op);
+
+        assert!(repo.latest(&target1).is_some());
+        assert!(repo.latest(&target2).is_some());
+        assert_eq!(repo.latest(&target1).unwrap(), create1_cid);
+        assert_eq!(repo.latest(&target2).unwrap(), create2_cid);
+        assert_ne!(create1_cid, create2_cid);
+    }
+}


### PR DESCRIPTION
## Description

<!-- A summary of what this pull request achieves and a rough list of changes. -->
以下追加と修正
- repo methodの追加: 上位レイヤーからこのmethodを使用することで、dag内にnodeの追加ができる
- nodeStorage構造体のエンコードとデコードの修正

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
repo methodでコメントしているテストはうまく動いていません。そしてunrap()で実装しており、エラーハンドリングができていないので、どの部分でエラーが起きているかが見つけられていません。
```
kind: InvalidSize(108)
```
が出ている。恐らくcidの生成 or nodeの生成部分なんだけど、先にエラーハンドリングについて実装を行います。