### PR TITLE
Fix: Handle operations with different genesis IDs targeting the same content ID

### DIFF
--- a/src/crdt/storage.rs
+++ b/src/crdt/storage.rs
@@ -220,4 +220,32 @@ mod tests {
         assert!(ops.contains(&op1));
         assert!(ops.contains(&op2));
     }
+
+    /// Demonstrates that an Update with different genesis is **not** returned when querying by target.
+    #[test]
+    fn test_same_target_different_genesis_ignored() {
+        let (storage, _dir) = setup_test_storage();
+        let target = DummyContentId("shared".into());
+        let payload = DummyPayload("one".into());
+        // Create (genesis = target)
+        let create = Operation::new(
+            target.clone(),
+            OperationType::Create(payload.clone()),
+            "u1".into(),
+        );
+        storage.save_operation(&create).unwrap();
+
+        // Update with DIFFERENT genesis but same target
+        let update = Operation::new_with_genesis(
+            target.clone(),
+            DummyContentId("DIFF".into()),
+            OperationType::Update(DummyPayload("two".into())),
+            "u1".into(),
+        );
+        storage.save_operation(&update).unwrap();
+
+        let ops = storage.load_operations(&target).unwrap();
+        // Expect 2 operations but will get only 1, hence panic.
+        assert_eq!(ops.len(), 2);
+    }
 }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -284,47 +284,45 @@ mod tests {
         assert_eq!(repo.latest(&genesis_a).unwrap(), latest_a);
         assert_eq!(repo.latest(&genesis_b).unwrap(), genesis_b);
     }
-}
 
-/// Failing test: Delete on one series still uses `target` and may fetch wrong payload.
-#[test]
-fn test_delete_mixes_series_due_to_target_lookup() {
-    let (mut repo, _) = setup_test_repo();
-    // 共有 Target CID
-    let shared_target = Cid::new_v1(
-        0x55,
-        multihash::Multihash::<64>::wrap(0x12, b"shared").unwrap(),
-    );
+    /// Failing test: Delete on one series still uses `target` and may fetch wrong payload.
+    #[test]
+    fn test_delete_mixes_series_due_to_target_lookup() {
+        let (mut repo, _) = setup_test_repo();
+        let shared_target = Cid::new_v1(
+            0x55,
+            multihash::Multihash::<64>::wrap(0x12, b"shared").unwrap(),
+        );
 
-    // User1: Create (genesis = shared_target)
-    let create1 = make_test_operation(
-        shared_target,
-        OperationType::Create(TestPayload("u1".into())),
-    );
-    let cid1 = repo.commit_operation(create1).unwrap();
+        // User1: Create
+        let create1 = make_test_operation(
+            shared_target,
+            OperationType::Create(TestPayload("u1".into())),
+        );
+        let cid1 = repo.commit_operation(create1).unwrap();
 
-    // User2: Create 自分用の genesis を得る
-    let create2 = make_test_operation(
-        shared_target,
-        OperationType::Create(TestPayload("u2".into())),
-    );
-    let cid2 = repo.commit_operation(create2).unwrap();
+        // User2: parallel series
+        let create2 = make_test_operation(
+            shared_target,
+            OperationType::Create(TestPayload("u2".into())),
+        );
+        let cid2 = repo.commit_operation(create2).unwrap();
 
-    // User2: Update with *different genesis* (cid2)
-    let update2 = make_test_operation_with_genesis(
-        shared_target,
-        cid2,
-        OperationType::Update(TestPayload("u2_updated".into())),
-    );
-    repo.commit_operation(update2).unwrap();
+        // User2 update in its own series
+        let update2 = make_test_operation_with_genesis(
+            shared_target,
+            cid2,
+            OperationType::Update(TestPayload("u2_updated".into())),
+        );
+        repo.commit_operation(update2).unwrap();
 
-    // User1: Delete (uses get_state(&target) internally)
-    let del_op = make_test_operation_with_genesis(shared_target, cid1, OperationType::Delete);
-    repo.commit_operation(del_op).unwrap();
+        // User1 delete
+        let del_op = make_test_operation_with_genesis(shared_target, cid1, OperationType::Delete);
+        repo.commit_operation(del_op).unwrap();
 
-    // 期待: 最新状態は "u2_updated" だが、実装は "u2" を参照するためパニック
-    assert_eq!(
-        repo.state.get_state(&shared_target),
-        Some(TestPayload("u2_updated".into()))
-    );
+        assert_eq!(
+            repo.state.get_state(&shared_target),
+            Some(TestPayload("u2_updated".into()))
+        );
+    }
 }


### PR DESCRIPTION
## Bug Report

When multiple operations target the same content ID but have different genesis IDs, the CRDT state incorrectly filters operations, causing data inconsistency.

### Issue
- Operations with different genesis IDs but same target ID are being ignored
- `get_state()` filters by `op.genesis == content_id`, missing updates from different series
- This causes the state to show outdated data instead of the latest updates

### Changes
- Added failing tests to demonstrate the collision bug in `crdt_state.rs`, `storage.rs`, and `repo.rs`
- Tests show that updates with different genesis IDs are incorrectly filtered out
- The expected behavior is to handle all operations targeting the same content ID regardless of genesis

### Test Cases Added
1. `test_same_target_different_genesis_collision` - Shows state incorrectly keeps older payload
2. `test_same_target_different_genesis_ignored` - Shows operations being filtered incorrectly  
3. `test_delete_mixes_series_due_to_target_lookup` - Shows delete operation fetching wrong payload

🤖 Generated with [Claude Code](https://claude.ai/code)